### PR TITLE
Wrap raw SQL in text() for task queries

### DIFF
--- a/ui/pages/adhd_mode.py
+++ b/ui/pages/adhd_mode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QListWidget, QListWidgetItem
 from PyQt6.QtCore import QTimer, Qt
 from datetime import datetime
+from sqlalchemy import text
 from project.db import get_engine
 
 
@@ -48,7 +49,9 @@ class ADHDModePage(QWidget):
         self.list_widget.clear()
         with self.engine.begin() as conn:
             rows = conn.execute(
-                "SELECT id, title, type, start_time, end_time FROM tasks WHERE state = 'pending' ORDER BY start_time"
+                text(
+                    "SELECT id, title, type, start_time, end_time FROM tasks WHERE state = 'pending' ORDER BY start_time"
+                )
             ).fetchall()
             for row in rows:
                 id_, title, ttype, start, end = row

--- a/ui/pages/tasks.py
+++ b/ui/pages/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QListWidget, QListWidgetItem
 from PyQt6.QtCore import Qt
 from datetime import datetime
+from sqlalchemy import text
 from project.db import get_engine
 from integrations.google_calendar import GoogleCalendarClient
 from agents.task_breakdown import breakdown_task
@@ -35,7 +36,9 @@ class TasksPage(QWidget):
         self.list_widget.clear()
         with self.engine.begin() as conn:
             rows = conn.execute(
-                "SELECT id, title, type, estimated_duration, due_date, state, start_time, end_time FROM tasks ORDER BY created_at"
+                text(
+                    "SELECT id, title, type, estimated_duration, due_date, state, start_time, end_time FROM tasks ORDER BY created_at"
+                )
             ).fetchall()
             for row in rows:
                 task_id, title, ttype, duration, due, state, start, end = row
@@ -81,7 +84,9 @@ class TasksPage(QWidget):
             # Insert into DB
             with self.engine.begin() as conn:
                 conn.execute(
-                    "INSERT INTO tasks (title, type, estimated_duration, due_date) VALUES (:title, :type, :duration, :due)",
+                    text(
+                        "INSERT INTO tasks (title, type, estimated_duration, due_date) VALUES (:title, :type, :duration, :due)"
+                    ),
                     {"title": title, "type": ttype, "duration": duration, "due": due_iso},
                 )
             dialog.accept()


### PR DESCRIPTION
## Summary
- Import SQLAlchemy `text` helper in ADHD and Tasks pages
- Execute SQL queries via `text()` to avoid ObjectNotExecutableError

## Testing
- `PYTHONPATH=. QT_QPA_PLATFORM=offscreen python scripts/dev_run.py` (no ObjectNotExecutableError)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899b5dc576c832e99333e96cee02a42