### PR TITLE
Prevent negative durations in task breakdown

### DIFF
--- a/agents/task_breakdown.py
+++ b/agents/task_breakdown.py
@@ -3,22 +3,28 @@ from typing import List, Dict
 
 
 def breakdown_task(task: Dict) -> List[Dict]:
-    """
-    Break down a complex task into smaller steps.
+    """Break down a complex task into smaller steps.
 
-    For demonstration, tasks with an estimated_duration > 60 minutes or type 'study' or 'project'
-    are split into two subtasks of equal duration.
-    Returns a list of new task dicts or an empty list if no breakdown needed.
+    Tasks are split when their ``estimated_duration`` is at least 60 minutes or the
+    task type is "study" or "project" and the duration meets the same threshold.
+    Shorter tasks are left untouched. The function returns a list of new task dicts
+    or an empty list if no breakdown is needed.
     """
-    duration = task.get('estimated_duration', 0)
-    ttype = task.get('type', '').lower()
-    if duration > 60 or ttype in {'study', 'project'}:
-        half = max(30, duration // 2)
+    duration = task.get("estimated_duration", 0)
+    ttype = task.get("type", "").lower()
+
+    if duration < 60:
+        return []
+
+    if duration > 60 or ttype in {"study", "project"}:
+        half = duration // 2
         subtask1 = task.copy()
-        subtask1['title'] = task['title'] + " (part 1)"
-        subtask1['estimated_duration'] = half
+        subtask1["title"] = task["title"] + " (part 1)"
+        subtask1["estimated_duration"] = half
+
         subtask2 = task.copy()
-        subtask2['title'] = task['title'] + " (part 2)"
-        subtask2['estimated_duration'] = duration - half
+        subtask2["title"] = task["title"] + " (part 2)"
+        subtask2["estimated_duration"] = duration - half
         return [subtask1, subtask2]
+
     return []

--- a/tests/test_task_breakdown.py
+++ b/tests/test_task_breakdown.py
@@ -22,3 +22,23 @@ def test_breakdown_small_task():
     }
     parts = breakdown_task(task)
     assert parts == []
+
+
+def test_short_study_task_no_split():
+    task = {
+        'title': 'Quick study session',
+        'estimated_duration': 20,
+        'type': 'study',
+    }
+    parts = breakdown_task(task)
+    assert parts == []
+
+
+def test_short_project_task_no_split():
+    task = {
+        'title': 'Minor project prep',
+        'estimated_duration': 45,
+        'type': 'project',
+    }
+    parts = breakdown_task(task)
+    assert parts == []


### PR DESCRIPTION
## Summary
- guard against splitting tasks when duration is below 60 minutes
- add tests verifying short study and project tasks are not split

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c3e07418832eb4252c3f7e93bc4a