### PR TITLE
Make task due date optional and add tests

### DIFF
--- a/tests/test_tasks_due_date.py
+++ b/tests/test_tasks_due_date.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from project.db import get_engine, ensure_db
+from sqlalchemy import text
+
+
+def _setup_engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = get_engine(str(db_path))
+    ensure_db(engine)
+    return engine
+
+
+def test_create_task_with_due_date(tmp_path):
+    engine = _setup_engine(tmp_path)
+    due = datetime(2024, 1, 1, 12, 0)
+    due_iso = due.isoformat()
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO tasks (title, type, estimated_duration, due_date) VALUES (:title, :type, :duration, :due)"
+            ),
+            {"title": "task", "type": "homework", "duration": 60, "due": due_iso},
+        )
+        row = conn.execute(text("SELECT due_date FROM tasks")).fetchone()
+        assert row is not None
+        assert row.due_date == due_iso
+
+
+def test_create_task_without_due_date(tmp_path):
+    engine = _setup_engine(tmp_path)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO tasks (title, type, estimated_duration, due_date) VALUES (:title, :type, :duration, :due)"
+            ),
+            {"title": "task", "type": "homework", "duration": 60, "due": None},
+        )
+        row = conn.execute(text("SELECT due_date FROM tasks")).fetchone()
+        assert row is not None
+        assert row.due_date is None
+


### PR DESCRIPTION
## Summary
- allow adding tasks without specifying a due date
- clean up unused imports in tasks page
- add database tests for tasks with and without due dates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c5fa1fdc832eb317fc176bb3950a