### PR TITLE
Refactor default appdata path creation

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 from pathlib import Path
+from pydantic import Field
 import os
 import platform
 
@@ -24,7 +25,8 @@ class Settings(BaseSettings):
     enable_dark_mode: bool = False
 
     # Storage defaults — put DB under user AppData unless SQLITE_PATH is set
-    def _default_appdata(self) -> Path:
+    @staticmethod
+    def _default_appdata() -> Path:
         sys = platform.system()
         if sys == "Windows":
             base = Path(os.getenv("APPDATA", Path.home() / "AppData" / "Roaming"))
@@ -36,9 +38,8 @@ class Settings(BaseSettings):
         d.mkdir(parents=True, exist_ok=True)
         return d
 
-    sqlite_path: str = (
-        os.getenv("SQLITE_PATH")
-        or str((_default_appdata.__get__(object)()) / "ai_study_buddy.db")
+    sqlite_path: str = Field(
+        default_factory=lambda: str(Settings._default_appdata() / "ai_study_buddy.db")
     )
 
     # Providers (kept optional; presence flips from sample→live mode)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+
+
+def test_default_path_created_on_settings_init_without_import_side_effect(tmp_path, monkeypatch):
+    """Ensure importing settings doesn't create the data directory, but initializing does."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SQLITE_PATH", raising=False)
+
+    expected_dir = tmp_path / ".local" / "share" / "AI-Study-Buddy"
+    assert not expected_dir.exists()
+
+    # Import module fresh to ensure import doesn't trigger directory creation
+    sys.modules.pop("project.settings", None)
+    settings_module = importlib.import_module("project.settings")
+
+    assert not expected_dir.exists(), "Importing settings should not create the directory"
+
+    s = settings_module.Settings()
+    assert expected_dir.exists(), "Instantiating Settings should create the directory"
+    assert s.sqlite_path == str(expected_dir / "ai_study_buddy.db")


### PR DESCRIPTION
## Summary
- ensure app data directory is created when Settings is instantiated
- prevent side effects on module import for default sqlite path
- add regression test covering Settings default path creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899ca2715d4832e9d42eabc0b4a0065