### PR TITLE
Include overlapping events in calendar queries

### DIFF
--- a/integrations/google_calendar.py
+++ b/integrations/google_calendar.py
@@ -45,7 +45,7 @@ class GoogleCalendarClient:
                 text(
                     "SELECT id, source, source_id, title, start_time, end_time, type, description "
                     "FROM events "
-                    "WHERE start_time >= :start AND end_time <= :end "
+                    "WHERE start_time < :end AND end_time > :start "
                     "ORDER BY start_time"
                 ),
                 {"start": start_time.isoformat(), "end": end_time.isoformat()},

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from integrations.google_calendar import GoogleCalendarClient
+from project.db import get_engine, ensure_db
+from sqlalchemy import text
+
+
+def test_list_events_overlapping_edges(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = get_engine(str(db_path))
+    ensure_db(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO events (source, source_id, title, start_time, end_time, type, description) "
+                "VALUES (:source, :source_id, :title, :start_time, :end_time, :type, :description)"
+            ),
+            [
+                {
+                    "source": "local",
+                    "source_id": "ev1",
+                    "title": "OverlapStart",
+                    "start_time": "2024-01-01T08:00:00",
+                    "end_time": "2024-01-01T09:30:00",
+                    "type": "meeting",
+                    "description": "",
+                },
+                {
+                    "source": "local",
+                    "source_id": "ev2",
+                    "title": "OverlapEnd",
+                    "start_time": "2024-01-01T09:30:00",
+                    "end_time": "2024-01-01T10:30:00",
+                    "type": "meeting",
+                    "description": "",
+                },
+                {
+                    "source": "local",
+                    "source_id": "ev3",
+                    "title": "Outside",
+                    "start_time": "2024-01-01T11:00:00",
+                    "end_time": "2024-01-01T12:00:00",
+                    "type": "meeting",
+                    "description": "",
+                },
+            ],
+        )
+    client = GoogleCalendarClient(engine)
+    start = datetime.fromisoformat("2024-01-01T09:00:00")
+    end = datetime.fromisoformat("2024-01-01T10:00:00")
+    events = client.list_events(start, end)
+    titles = {e["title"] for e in events}
+    assert "OverlapStart" in titles
+    assert "OverlapEnd" in titles
+    assert "Outside" not in titles
+    assert len(events) == 2


### PR DESCRIPTION
## Summary
- Expand Google Calendar query to return events overlapping the time window
- Add tests verifying events that start before or end after the window are still fetched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f450c204832e9caefa2423218781