### PR TITLE
Handle overflow tasks in scheduler

### DIFF
--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
+
 from agents.planner import schedule_tasks
 
 
@@ -31,3 +32,37 @@ def test_schedule_tasks_avoids_event_overlap():
     # tasks should not overlap each other
     t1, t2 = scheduled
     assert t1['end_time'] <= t2['start_time'] or t2['end_time'] <= t1['start_time']
+
+
+def test_schedule_tasks_rolls_over_when_start_after_work_end():
+    tasks = [
+        {'id': 1, 'title': 'Task A', 'type': 'homework', 'estimated_duration': 60, 'due_date': None},
+        {'id': 2, 'title': 'Task B', 'type': 'study', 'estimated_duration': 45, 'due_date': None},
+    ]
+    scheduled = schedule_tasks(tasks, [], work_start=time(9, 0), work_end=time(10, 0))
+    assert len(scheduled) == 2
+    first, second = scheduled
+    # First task fills the day
+    assert first['start_time'].time() == time(9, 0)
+    assert first['end_time'].time() == time(10, 0)
+    # Second task should roll to next day's start
+    next_day = first['start_time'].date() + timedelta(days=1)
+    assert second['start_time'] == datetime.combine(next_day, time(9, 0))
+    assert second['end_time'] == second['start_time'] + timedelta(minutes=45)
+
+
+def test_schedule_tasks_rolls_over_when_end_exceeds_work_end():
+    tasks = [
+        {'id': 1, 'title': 'Task A', 'type': 'homework', 'estimated_duration': 50, 'due_date': None},
+        {'id': 2, 'title': 'Task B', 'type': 'study', 'estimated_duration': 30, 'due_date': None},
+    ]
+    scheduled = schedule_tasks(tasks, [], work_start=time(9, 0), work_end=time(10, 0))
+    assert len(scheduled) == 2
+    first, second = scheduled
+    # First task takes most of the day
+    assert first['start_time'].time() == time(9, 0)
+    assert first['end_time'].time() == time(9, 50)
+    # Second task cannot finish before work_end, so it should roll to next day
+    next_day = first['start_time'].date() + timedelta(days=1)
+    assert second['start_time'] == datetime.combine(next_day, time(9, 0))
+    assert second['end_time'] == second['start_time'] + timedelta(minutes=30)


### PR DESCRIPTION
## Summary
- roll tasks to the next work day when no space remains in today's work window
- add tests covering task scheduling that spills into the next work day

## Testing
- `pytest tests/test_planner.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f676bf4c832e8fde6fe5bb436106