### PR TITLE
Milestone 2 — Incremental Google import with cursors & idempotent merge

### DIFF
--- a/migrations/versions/0002_smart_task_integration.py
+++ b/migrations/versions/0002_smart_task_integration.py
@@ -1,0 +1,65 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0002_smart_task_integration'
+down_revision = '0001_init'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'events',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.Column('source_id', sa.String(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('start_time', sa.String(), nullable=False),
+        sa.Column('end_time', sa.String(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=False, server_default=''),
+    )
+    op.create_index('events_source_idx', 'events', ['source', 'source_id'], unique=True)
+
+    op.create_table(
+        'tasks',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('estimated_duration', sa.Integer(), nullable=False),
+        sa.Column('due_date', sa.String()),
+        sa.Column('course_label', sa.String()),
+        sa.Column('created_at', sa.String(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.String(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('start_time', sa.String()),
+        sa.Column('end_time', sa.String()),
+        sa.Column('state', sa.String(), nullable=False, server_default='pending'),
+    )
+
+    op.create_table(
+        'staging_events',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.Column('source_id', sa.String(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('start_time', sa.String(), nullable=False),
+        sa.Column('end_time', sa.String(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=False, server_default=''),
+        sa.Column('updated_at', sa.String(), nullable=False),
+    )
+
+    op.create_table(
+        'sync_cursors',
+        sa.Column('provider', sa.String(), primary_key=True),
+        sa.Column('cursor', sa.String(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('sync_cursors')
+    op.drop_table('staging_events')
+    op.drop_table('tasks')
+    op.drop_index('events_source_idx', table_name='events')
+    op.drop_table('events')

--- a/project/db_merge.py
+++ b/project/db_merge.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from typing import Dict, Any, Optional
+from datetime import datetime
+from sqlalchemy import text
+
+
+def _norm_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    for key in ["source", "source_id", "title", "start_time", "end_time", "type", "description"]:
+        val = event.get(key)
+        if key in ("start_time", "end_time") and isinstance(val, datetime):
+            payload[key] = val.isoformat()
+        else:
+            payload[key] = val
+    return payload
+
+
+def merge_event(conn, event: Dict[str, Any]) -> int:
+    """Insert or update an event record and return its id.
+
+    Deduplicate by (source, source_id) if present. As a fallback, deduplicate
+    by (title, start_time).
+    """
+    payload = _norm_event(event)
+    lookup = {"source": payload["source"], "source_id": payload["source_id"]}
+    row = conn.execute(
+        text("SELECT id FROM events WHERE source = :source AND source_id = :source_id"),
+        lookup,
+    ).fetchone()
+    if row:
+        event_id = int(row.id if hasattr(row, "id") else row[0])
+        conn.execute(
+            text(
+                "UPDATE events SET title=:title, start_time=:start_time, end_time=:end_time, "
+                "type=:type, description=:description WHERE id=:id"
+            ),
+            {**payload, "id": event_id},
+        )
+        return event_id
+    # Fallback dedupe by title + start_time
+    row = conn.execute(
+        text("SELECT id FROM events WHERE title = :title AND start_time = :start_time"),
+        {"title": payload["title"], "start_time": payload["start_time"]},
+    ).fetchone()
+    if row:
+        event_id = int(row.id if hasattr(row, "id") else row[0])
+        conn.execute(
+            text(
+                "UPDATE events SET source=:source, source_id=:source_id, end_time=:end_time, "
+                "type=:type, description=:description WHERE id=:id"
+            ),
+            {**payload, "id": event_id},
+        )
+        return event_id
+    # Insert new
+    conn.execute(
+        text(
+            "INSERT INTO events (source, source_id, title, start_time, end_time, type, description) "
+            "VALUES (:source, :source_id, :title, :start_time, :end_time, :type, :description)"
+        ),
+        payload,
+    )
+    event_id = conn.execute(text("SELECT last_insert_rowid() AS id")).scalar_one()
+    return int(event_id)
+
+
+def get_cursor(conn, provider: str) -> Optional[str]:
+    row = conn.execute(
+        text("SELECT cursor FROM sync_cursors WHERE provider = :provider"),
+        {"provider": provider},
+    ).fetchone()
+    if row:
+        return row.cursor if hasattr(row, "cursor") else row[0]
+    return None
+
+
+def set_cursor(conn, provider: str, cursor: str) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO sync_cursors(provider, cursor) VALUES(:provider, :cursor) "
+            "ON CONFLICT(provider) DO UPDATE SET cursor = excluded.cursor"
+        ),
+        {"provider": provider, "cursor": cursor},
+    )

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+from datetime import datetime
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+
+from project.db import get_engine
+from project.db_merge import merge_event, get_cursor, set_cursor
+from integrations.google_calendar import GoogleCalendarClient
+
+
+def run_migrations(db_path: Path) -> None:
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+    cfg.set_main_option("script_location", str(Path(__file__).resolve().parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, "head")
+
+
+def setup_engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    run_migrations(db_path)
+    return get_engine(str(db_path))
+
+
+def test_merge_event_idempotent(tmp_path):
+    engine = setup_engine(tmp_path)
+    ev = {
+        "source": "google",
+        "source_id": "ev1",
+        "title": "Meeting",
+        "start_time": "2024-01-01T09:00:00",
+        "end_time": "2024-01-01T10:00:00",
+        "type": "meeting",
+        "description": "",
+    }
+    with engine.begin() as conn:
+        id1 = merge_event(conn, ev)
+        id2 = merge_event(conn, ev)
+        assert id1 == id2
+        count = conn.execute(text("SELECT COUNT(*) FROM events")).scalar_one()
+        assert count == 1
+
+
+def test_cursor_roundtrip(tmp_path):
+    engine = setup_engine(tmp_path)
+    with engine.begin() as conn:
+        assert get_cursor(conn, "google") is None
+        set_cursor(conn, "google", "2024-01-01T00:00:00")
+        assert get_cursor(conn, "google") == "2024-01-01T00:00:00"
+        set_cursor(conn, "google", "2024-01-02T00:00:00")
+        assert get_cursor(conn, "google") == "2024-01-02T00:00:00"
+
+
+def test_client_list_and_fetch_since(tmp_path):
+    engine = setup_engine(tmp_path)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO staging_events (source, source_id, title, start_time, end_time, type, description, updated_at) "
+                "VALUES (:source, :source_id, :title, :start_time, :end_time, :type, :description, :updated_at)"
+            ),
+            [
+                {
+                    "source": "google",
+                    "source_id": "1",
+                    "title": "Event1",
+                    "start_time": "2024-01-01T09:00:00",
+                    "end_time": "2024-01-01T10:00:00",
+                    "type": "meeting",
+                    "description": "",
+                    "updated_at": "2024-01-01T08:00:00",
+                },
+                {
+                    "source": "google",
+                    "source_id": "2",
+                    "title": "Event2",
+                    "start_time": "2024-01-02T09:00:00",
+                    "end_time": "2024-01-02T10:00:00",
+                    "type": "meeting",
+                    "description": "",
+                    "updated_at": "2024-01-02T08:00:00",
+                },
+            ],
+        )
+    client = GoogleCalendarClient(engine)
+    cursor = client.fetch_since("google")
+    with engine.begin() as conn:
+        stored = get_cursor(conn, "google")
+    assert stored == cursor
+    start = datetime.fromisoformat("2024-01-01T00:00:00")
+    end = datetime.fromisoformat("2024-01-03T00:00:00")
+    events = client.list_events(start, end)
+    titles = {e["title"] for e in events}
+    assert {"Event1", "Event2"} <= titles
+    cursor2 = client.fetch_since("google", cursor)
+    assert cursor2 > cursor
+    events2 = client.list_events(start, end)
+    assert len(events2) == len(events)


### PR DESCRIPTION
## Summary
- add merge helpers and cursor storage for incremental event import
- implement `fetch_since` to pull staged events into main calendar with sync cursors
- create migration for staging events and cursor tables with tests for idempotent merge

## Key Changes
- `integrations/google_calendar.py`
- `project/db_merge.py`
- `migrations/versions/0002_smart_task_integration.py`
- `tests/test_import_pipeline.py`

## How to Test
- `alembic upgrade head`
- `pytest -q`

## Acceptance Checklist
- [x] Re-running fetch_since() with the same staging_events is idempotent (no dupes)
- [x] sync_cursors gets updated to a later ISO timestamp
- [x] list_events() returns merged events in the given window
- [x] All tests pass on Codex’s machine

## Notes
- sample mode uses local tables; real Google API keys not required


------
https://chatgpt.com/codex/tasks/task_e_689a262eb0c8832e848fc960b7305071