### PR TITLE
Milestone 2 — Tasks filters & search

### DIFF
--- a/tests/test_tasks_filters.py
+++ b/tests/test_tasks_filters.py
@@ -1,0 +1,335 @@
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+from ui.pages.tasks import build_tasks_query
+
+
+def setup_engine(rows):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    estimated_duration INTEGER NOT NULL,
+                    due_date TEXT,
+                    course_label TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT,
+                    start_time TEXT,
+                    end_time TEXT,
+                    state TEXT NOT NULL,
+                    priority INTEGER,
+                    created_by TEXT
+                )
+                """
+            )
+        )
+        for row in rows:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tasks
+                    (title, type, estimated_duration, due_date, course_label, created_at, start_time, end_time, state, priority)
+                    VALUES (:title, :type, :estimated_duration, :due_date, :course_label, :created_at, :start_time, :end_time, :state, :priority)
+                    """
+                ),
+                row,
+            )
+    return engine
+
+
+def run_query(engine, filter_mode, search=""):
+    sql, params = build_tasks_query(filter_mode, search)
+    with engine.begin() as conn:
+        rows = conn.execute(text(sql), params).fetchall()
+    return [r[0] for r in rows]
+
+
+def test_filter_today_includes_pending_and_todays_scheduled():
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = today + timedelta(days=1)
+    rows = [
+        {
+            "title": "Pending",
+            "type": "study",
+            "estimated_duration": 60,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "Today Event",
+            "type": "class",
+            "estimated_duration": 60,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": (today + timedelta(hours=9)).isoformat(),
+            "end_time": (today + timedelta(hours=10)).isoformat(),
+            "state": "done",
+            "priority": None,
+        },
+        {
+            "title": "Pending Tomorrow",
+            "type": "class",
+            "estimated_duration": 60,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-03T00:00:00",
+            "start_time": (tomorrow + timedelta(hours=9)).isoformat(),
+            "end_time": (tomorrow + timedelta(hours=10)).isoformat(),
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "Tomorrow Event",
+            "type": "class",
+            "estimated_duration": 60,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-04T00:00:00",
+            "start_time": (tomorrow + timedelta(hours=11)).isoformat(),
+            "end_time": (tomorrow + timedelta(hours=12)).isoformat(),
+            "state": "done",
+            "priority": None,
+        },
+    ]
+    engine = setup_engine(rows)
+    ids = run_query(engine, "Today")
+    assert ids == [1, 2, 3]
+
+
+def test_filter_upcoming_by_due_date_only():
+    base = datetime.now().date()
+    rows = [
+        {
+            "title": "Due1",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=1)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "Due2",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=2)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "NoDue",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-03T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+    ]
+    engine = setup_engine(rows)
+    ids = run_query(engine, "Upcoming")
+    assert ids == [1, 2]
+
+
+def test_filter_by_course_sorts_grouped():
+    base = datetime.now().date()
+    rows = [
+        {
+            "title": "NoCourse",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=5)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "BioB",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=2)).isoformat(),
+            "course_label": "BIO",
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "BioA",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=1)).isoformat(),
+            "course_label": "BIO",
+            "created_at": "2024-01-03T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "Math",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": "MATH",
+            "created_at": "2024-01-04T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+    ]
+    engine = setup_engine(rows)
+    ids = run_query(engine, "By Course")
+    assert ids == [1, 3, 2, 4]
+
+
+def test_filter_by_priority_orders_correctly():
+    base = datetime.now().date()
+    rows = [
+        {
+            "title": "P1 later",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=4)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": 1,
+        },
+        {
+            "title": "P2",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=2)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": 2,
+        },
+        {
+            "title": "Pnull",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=3)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-03T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "P1 sooner",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": (base + timedelta(days=1)).isoformat(),
+            "course_label": None,
+            "created_at": "2024-01-04T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": 1,
+        },
+    ]
+    engine = setup_engine(rows)
+    ids = run_query(engine, "By Priority")
+    assert ids == [4, 1, 2, 3]
+
+
+def test_search_matches_title_type_course():
+    rows = [
+        {
+            "title": "Read Book",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": "ENG",
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "Essay",
+            "type": "homework",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": "MATH",
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+    ]
+    engine = setup_engine(rows)
+    assert run_query(engine, "All", "read") == [1]
+    assert run_query(engine, "All", "homework") == [2]
+    assert run_query(engine, "All", "eng") == [1]
+
+
+def test_all_shows_everything():
+    rows = [
+        {
+            "title": "A",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-01T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+        {
+            "title": "B",
+            "type": "study",
+            "estimated_duration": 30,
+            "due_date": None,
+            "course_label": None,
+            "created_at": "2024-01-02T00:00:00",
+            "start_time": None,
+            "end_time": None,
+            "state": "pending",
+            "priority": None,
+        },
+    ]
+    engine = setup_engine(rows)
+    ids = run_query(engine, "All")
+    assert ids == [1, 2]

--- a/ui/pages/tasks.py
+++ b/ui/pages/tasks.py
@@ -6,16 +6,60 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QListWidget,
     QListWidgetItem,
+    QComboBox,
+    QLineEdit,
 )
-from datetime import datetime
+from PyQt6.QtCore import QTimer
+from datetime import datetime, timedelta
 from sqlalchemy import text
 from agents import classifier
 
 
+def build_tasks_query(filter_mode: str, search: str):
+    """Construct the SQL query and parameters for a tasks view."""
+    where_clauses = []
+    params: dict[str, str] = {}
+
+    if filter_mode == "Today":
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        tomorrow = today + timedelta(days=1)
+        params["today"] = today.isoformat()
+        params["tomorrow"] = tomorrow.isoformat()
+        where_clauses.append(
+            "(state = 'pending' OR (start_time >= :today AND start_time < :tomorrow))"
+        )
+        order_clause = "ORDER BY COALESCE(start_time, due_date)"
+    elif filter_mode == "Upcoming":
+        where_clauses.append("due_date IS NOT NULL")
+        order_clause = "ORDER BY due_date"
+    elif filter_mode == "By Course":
+        order_clause = "ORDER BY COALESCE(course_label, ''), COALESCE(due_date, '9999-12-31')"
+    elif filter_mode == "By Priority":
+        order_clause = "ORDER BY COALESCE(priority, 3), COALESCE(due_date, '9999-12-31')"
+    else:  # All
+        order_clause = "ORDER BY created_at"
+
+    if search:
+        params["q"] = f"%{search.lower()}%"
+        where_clauses.append(
+            "(LOWER(title) LIKE :q OR LOWER(type) LIKE :q OR LOWER(COALESCE(course_label,'')) LIKE :q)"
+        )
+
+    where_sql = ""
+    if where_clauses:
+        where_sql = "WHERE " + " AND ".join(where_clauses)
+
+    sql = (
+        "SELECT id, title, type, estimated_duration, due_date, state, start_time, end_time, "
+        "course_label, priority FROM tasks "
+        f"{where_sql} {order_clause}"
+    )
+    return sql, params
+
+
 class TasksPage(QWidget):
-    """
-    Page to display and manage user tasks. Allows adding tasks and viewing existing ones.
-    """
+    """Page to display and manage user tasks with filters and search."""
+
     def __init__(self, engine, parent=None):
         super().__init__(parent)
         self.engine = engine
@@ -28,6 +72,19 @@ class TasksPage(QWidget):
         self.add_btn.clicked.connect(self.on_add_task)
         layout.addWidget(self.add_btn)
 
+        self.filter_combo = QComboBox()
+        self.filter_combo.addItems(["Today", "Upcoming", "By Course", "By Priority", "All"])
+        self.filter_combo.currentTextChanged.connect(self.refresh_list)
+        layout.addWidget(self.filter_combo)
+
+        self.search_edit = QLineEdit()
+        layout.addWidget(self.search_edit)
+        self.search_timer = QTimer(self)
+        self.search_timer.setInterval(250)
+        self.search_timer.setSingleShot(True)
+        self.search_timer.timeout.connect(self.refresh_list)
+        self.search_edit.textChanged.connect(lambda: self.search_timer.start())
+
         self.list_widget = QListWidget()
         layout.addWidget(self.list_widget)
 
@@ -37,22 +94,33 @@ class TasksPage(QWidget):
     def refresh_list(self):
         """Load tasks from DB and display them in the list widget."""
         self.list_widget.clear()
+        filter_mode = self.filter_combo.currentText() if hasattr(self, "filter_combo") else "All"
+        search = self.search_edit.text() if hasattr(self, "search_edit") else ""
+        sql, params = build_tasks_query(filter_mode, search)
+        self.list_widget.clear()
         with self.engine.begin() as conn:
-            rows = conn.execute(
-                text(
-                    "SELECT id, title, type, estimated_duration, due_date, state, start_time, end_time, course_label, priority FROM tasks ORDER BY created_at"
-                )
-            ).fetchall()
+            rows = conn.execute(text(sql), params).fetchall()
             for row in rows:
                 task_id, title, ttype, duration, due, state, start, end, course, priority = row
-                due_str = f"Due: {due}" if due else ""
-                state_str = f"[{state}]"
-                time_str = ""
+                parts = [f"#{task_id} [{state}] {title} ({ttype}, {duration}m)"]
+                if course:
+                    parts.append(f"• {course}")
+                if priority is not None:
+                    parts.append(f"• p{priority}")
+                if due:
+                    try:
+                        due_disp = datetime.fromisoformat(due).date().isoformat()
+                    except Exception:
+                        due_disp = due
+                    parts.append(f"– due {due_disp}")
                 if start and end:
-                    time_str = f" | {start} → {end}"
-                course_str = f"[{course}]" if course else ""
-                priority_str = f"P{priority}" if priority is not None else ""
-                item_text = f"#{task_id}: {title} {course_str} {priority_str} ({ttype}, {duration}m) {state_str} {due_str}{time_str}"
+                    try:
+                        start_t = datetime.fromisoformat(start).strftime("%H:%M")
+                        end_t = datetime.fromisoformat(end).strftime("%H:%M")
+                        parts.append(f"| {start_t}→{end_t}")
+                    except Exception:
+                        pass
+                item_text = " ".join(parts)
                 self.list_widget.addItem(QListWidgetItem(item_text))
 
     def on_add_task(self):


### PR DESCRIPTION
## Summary
- Add a reusable SQL builder to support Tasks page filters and search
- Implement filter combo and debounced search in the Tasks UI
- Render compact task info including course labels, priority, due dates and schedule
- Add tests for all filters and search combinations

## Key Changes
- `ui/pages/tasks.py`
- `tests/test_tasks_filters.py`

## How to Test
- `python -m venv .venv`
- `source .venv/bin/activate`
- `pip install -r requirements.txt`
- `alembic upgrade head`
- `pytest -q`

## Acceptance Checklist
- [x] Filter combo implements Today / Upcoming / By Course / By Priority / All
- [x] Search debounces and combines with active filter
- [x] Items render with course label and priority when present
- [x] Tests in tests/test_tasks_filters.py all pass


------
https://chatgpt.com/codex/tasks/task_e_689a2b2f13f0832ebafaa5c92f524a59