### PR TITLE
Milestone 3 — Constraint‑aware planner engine (backend)

### DIFF
--- a/agents/planner_engine.py
+++ b/agents/planner_engine.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timedelta, time, date
+from typing import List, Dict, Optional, Tuple
+from collections import defaultdict
+
+from project.prefs import UserPrefs
+
+
+def _to_datetime(value: Optional[datetime | date | str], end_of_day: time) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime.combine(value, end_of_day)
+    try:
+        return datetime.fromisoformat(value)
+    except Exception:
+        return None
+
+
+def _subtract_intervals(base: List[Tuple[datetime, datetime]], busy: List[Tuple[datetime, datetime]]) -> List[Tuple[datetime, datetime]]:
+    """Subtract busy intervals from base intervals."""
+    result: List[Tuple[datetime, datetime]] = []
+    busy_sorted = sorted(busy)
+    for start, end in base:
+        cur = start
+        for bstart, bend in busy_sorted:
+            if bend <= cur or bstart >= end:
+                continue
+            if bstart > cur:
+                result.append((cur, min(bstart, end)))
+            cur = max(cur, bend)
+            if cur >= end:
+                break
+        if cur < end:
+            result.append((cur, end))
+    return result
+
+
+def schedule(tasks: List[Dict], events: List[Dict], blocks: List[Dict], prefs: UserPrefs, *, start: Optional[datetime] = None, horizon_days: int = 7) -> List[Dict]:
+    """
+    Schedule tasks into study sessions respecting events, blocks, deadlines and preferences.
+    Returns list of sessions with keys: task_id, title, start_time, end_time, rationale.
+    """
+    base_dt = (start or datetime.now()).replace(second=0, microsecond=0)
+    today = base_dt.date()
+    horizon_end = datetime.combine(today, time.min) + timedelta(days=horizon_days)
+
+    # Build busy intervals from events and busy blocks
+    busy: List[Tuple[datetime, datetime]] = []
+    for ev in events:
+        busy.append((ev['start_time'], ev['end_time']))
+    for b in blocks:
+        if b.get('kind') == 'busy':
+            busy.append((b['start_time'], b['end_time']))
+    busy.sort()
+
+    # Build study windows (intersection with prefs day_start/day_end)
+    study_blocks = [b for b in blocks if b.get('kind') == 'study_window']
+    daily_windows: List[Tuple[datetime, datetime]] = []
+    for offset in range(horizon_days):
+        day = today + timedelta(days=offset)
+        base_start = datetime.combine(day, prefs.day_start)
+        base_end = datetime.combine(day, prefs.day_end)
+        if base_start >= horizon_end:
+            break
+        relevant: List[Tuple[datetime, datetime]] = []
+        for sw in study_blocks:
+            sw_start, sw_end = sw['start_time'], sw['end_time']
+            if sw_end <= base_start or sw_start >= base_end:
+                continue
+            start_i = max(base_start, sw_start)
+            end_i = min(base_end, sw_end)
+            if start_i < end_i:
+                relevant.append((start_i, end_i))
+        if relevant:
+            daily_windows.extend(relevant)
+        else:
+            daily_windows.append((base_start, base_end))
+
+    free_slots = _subtract_intervals(daily_windows, busy)
+    free_slots.sort()
+
+    # Sort tasks
+    def task_key(t: Dict):
+        due_dt = _to_datetime(t.get('due_date'), prefs.day_end) or horizon_end
+        priority = t.get('priority') if t.get('priority') is not None else 999
+        return (due_dt, priority, -t.get('estimated_duration', 0))
+
+    tasks_sorted = sorted([t for t in tasks if t.get('state') in (None, 'pending')], key=task_key)
+
+    sessions: List[Dict] = []
+    sessions_per_day: defaultdict[date, int] = defaultdict(int)
+
+    # Scheduler loop
+    for task in tasks_sorted:
+        remaining = task.get('estimated_duration', 0)
+        if remaining <= 0:
+            continue
+        due_dt = _to_datetime(task.get('due_date'), prefs.day_end) or horizon_end
+
+        i = 0
+        while remaining > 0 and i < len(free_slots):
+            slot_start, slot_end = free_slots[i]
+            day = slot_start.date()
+            if slot_start >= due_dt:
+                break
+            if sessions_per_day[day] >= prefs.max_sessions_per_day:
+                i += 1
+                continue
+            allowed_end = min(slot_end, due_dt)
+            if allowed_end <= slot_start:
+                i += 1
+                continue
+            available = (allowed_end - slot_start).total_seconds() / 60
+            if available <= 0:
+                i += 1
+                continue
+            chunk = min(prefs.default_session_minutes, remaining, available)
+            session_start = slot_start
+            session_end = session_start + timedelta(minutes=chunk)
+            sessions.append({
+                'task_id': task['id'],
+                'title': task['title'],
+                'type': task.get('type'),
+                'start_time': session_start,
+                'end_time': session_end,
+                'rationale': f"due {due_dt.date()} priority {task.get('priority')}",
+            })
+            remaining -= chunk
+            sessions_per_day[day] += 1
+            # Update slot
+            new_start = session_end
+            if new_start < slot_end and new_start < allowed_end and sessions_per_day[day] < prefs.max_sessions_per_day:
+                free_slots[i] = (new_start, slot_end)
+            else:
+                free_slots.pop(i)
+                continue  # don't increment i; next slot now at same index
+            if remaining <= 0:
+                break
+        # end while slots
+    return sessions

--- a/migrations/versions/0004_planner_prefs_and_blocks.py
+++ b/migrations/versions/0004_planner_prefs_and_blocks.py
@@ -1,0 +1,40 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = '0004_planner_prefs_and_blocks'
+down_revision = '0003_task_fields_and_indexes'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'blocks',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('kind', sa.String(), nullable=False),
+        sa.Column('start_time', sa.String(), nullable=False),
+        sa.Column('end_time', sa.String(), nullable=False),
+        sa.Column('source', sa.String(), nullable=True),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.CheckConstraint("kind IN ('busy','study_window')", name='blocks_kind_check'),
+    )
+    op.create_index('blocks_start_idx', 'blocks', ['start_time'])
+    op.create_index('blocks_end_idx', 'blocks', ['end_time'])
+
+    op.create_table(
+        'prefs',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('day_start', sa.String(), nullable=True),
+        sa.Column('day_end', sa.String(), nullable=True),
+        sa.Column('default_session_minutes', sa.Integer(), nullable=True),
+        sa.Column('max_sessions_per_day', sa.Integer(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('prefs')
+    op.drop_index('blocks_end_idx', table_name='blocks')
+    op.drop_index('blocks_start_idx', table_name='blocks')
+    op.drop_table('blocks')

--- a/project/prefs.py
+++ b/project/prefs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import time
+from typing import Optional
+
+from .settings import load_settings, Settings
+
+
+@dataclass
+class UserPrefs:
+    day_start: time = time(8, 0)
+    day_end: time = time(22, 0)
+    default_session_minutes: int = 50
+    max_sessions_per_day: int = 6
+
+
+def _parse_time(value: Optional[str]) -> Optional[time]:
+    if value is None:
+        return None
+    if isinstance(value, time):
+        return value
+    try:
+        hour, minute = map(int, str(value).split(":"))
+        return time(hour, minute)
+    except Exception:
+        return None
+
+
+def load_prefs(settings: Optional[Settings] = None) -> UserPrefs:
+    settings = settings or load_settings()
+    start = _parse_time(getattr(settings, "day_start", None)) or UserPrefs.day_start
+    end = _parse_time(getattr(settings, "day_end", None)) or UserPrefs.day_end
+    default_minutes = getattr(settings, "default_session_minutes", UserPrefs.default_session_minutes)
+    max_sessions = getattr(settings, "max_sessions_per_day", UserPrefs.max_sessions_per_day)
+    return UserPrefs(day_start=start, day_end=end, default_session_minutes=default_minutes, max_sessions_per_day=max_sessions)

--- a/tests/test_planner_engine.py
+++ b/tests/test_planner_engine.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from datetime import datetime, time, timedelta
+
+from agents.planner_engine import schedule
+from project.prefs import UserPrefs
+
+
+def _prefs():
+    return UserPrefs(day_start=time(8, 0), day_end=time(12, 0), default_session_minutes=60, max_sessions_per_day=2)
+
+
+def test_respects_events_and_blocks():
+    base = datetime(2024, 1, 1, 8, 0)
+    tasks = [
+        {"id": 1, "title": "Task", "estimated_duration": 60, "due_date": base + timedelta(days=1), "priority": 1, "state": "pending"}
+    ]
+    events = [
+        {"start_time": base.replace(hour=9), "end_time": base.replace(hour=10), "title": "Meeting"},
+    ]
+    blocks = [
+        {"kind": "busy", "start_time": base.replace(hour=8), "end_time": base.replace(hour=9)},
+        {"kind": "busy", "start_time": base.replace(hour=10), "end_time": base.replace(hour=11)},
+        {"kind": "study_window", "start_time": base.replace(hour=8), "end_time": base.replace(hour=12)},
+    ]
+    sessions = schedule(tasks, events, blocks, _prefs(), start=base)
+    assert sessions[0]["start_time"] == base.replace(hour=11)
+    assert sessions[0]["end_time"] == base.replace(hour=12)
+
+
+def test_deadline_before_window_pushes_up_priority():
+    base = datetime(2024, 1, 1, 8, 0)
+    tasks = [
+        {"id": 1, "title": "Later", "estimated_duration": 60, "due_date": base + timedelta(days=3), "priority": 1, "state": "pending"},
+        {"id": 2, "title": "Soon", "estimated_duration": 60, "due_date": base + timedelta(days=1), "priority": 5, "state": "pending"},
+    ]
+    sessions = schedule(tasks, [], [], _prefs(), start=base)
+    assert sessions[0]["task_id"] == 2
+
+
+def test_splits_into_sessions_and_limits_per_day():
+    base = datetime(2024, 1, 1, 8, 0)
+    tasks = [
+        {"id": 1, "title": "Big", "estimated_duration": 180, "due_date": base + timedelta(days=3), "priority": 1, "state": "pending"}
+    ]
+    sessions = schedule(tasks, [], [], _prefs(), start=base)
+    assert len(sessions) == 3
+    assert sessions[0]["start_time"] == base.replace(hour=8)
+    assert sessions[1]["start_time"] == base.replace(hour=9)
+    # third session on next day 8am
+    assert sessions[2]["start_time"] == base.replace(day=2, hour=8)
+
+
+def test_does_not_schedule_past_due():
+    base = datetime(2024, 1, 1, 8, 0)
+    tasks = [
+        {"id": 1, "title": "DueEarly", "estimated_duration": 150, "due_date": base.replace(hour=9, minute=30), "priority": 1, "state": "pending"}
+    ]
+    sessions = schedule(tasks, [], [], _prefs(), start=base)
+    # Total scheduled time should end exactly at due date
+    assert sessions[-1]["end_time"] <= base.replace(hour=9, minute=30)


### PR DESCRIPTION
## Summary
- add deterministic planner engine to schedule tasks within study windows and busy blocks
- introduce user preference dataclass and database migration for blocks and prefs
- update planner page to use new engine and return sessions for future integrations

## Testing
- `alembic upgrade head`
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a37a66f14832e964ef53fd8d1378f