### PR TITLE
Milestone 3 — Background workers and retry queue

### DIFF
--- a/project/logging.py
+++ b/project/logging.py
@@ -21,3 +21,8 @@ def configure_logging(level: str = "INFO") -> structlog.BoundLogger:
         cache_logger_on_first_use=True,
     )
     return structlog.get_logger()
+
+
+def get_logger() -> structlog.BoundLogger:
+    """Return a bound logger configured for the application."""
+    return structlog.get_logger()

--- a/scripts/dev_run.py
+++ b/scripts/dev_run.py
@@ -6,11 +6,13 @@ from project.logging import configure_logging
 from project.db import get_engine, ensure_db
 from ui.main_window import MainWindow
 from utils.error_handler import install_global_exception_hook
+from utils.workers import init_worker_pool
 
 
 def main():
     settings = load_settings()
     logger = configure_logging(settings.app_log_level)
+    init_worker_pool(logger)
     engine = get_engine(settings.sqlite_path)
     ensure_db(engine)
     install_global_exception_hook(logger)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import threading
+import time
+from PyQt6.QtCore import QCoreApplication
+
+from utils.jobs import JobType, JOB_HANDLERS
+from utils.workers import WorkerPool
+
+
+def test_job_runs_off_ui_thread(monkeypatch):
+    QCoreApplication([])
+    pool = WorkerPool()
+    main_thread = threading.get_ident()
+    done = threading.Event()
+    result: dict[str, int] = {}
+
+    def handler(payload):
+        result["thread"] = threading.get_ident()
+        done.set()
+
+    monkeypatch.setitem(JOB_HANDLERS, JobType.PLAN_WEEK, handler)
+    pool.submit(JobType.PLAN_WEEK)
+    assert done.wait(1)
+    assert result["thread"] != main_thread
+
+
+def test_retry_and_backoff_called(monkeypatch):
+    QCoreApplication([])
+    pool = WorkerPool()
+    attempts = {"count": 0}
+    done = threading.Event()
+    delays: list[float] = []
+
+    def handler(payload):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise ValueError("boom")
+        done.set()
+
+    class InstantTimer:
+        def __init__(self, delay, callback):
+            delays.append(delay)
+            self.callback = callback
+
+        def start(self):
+            self.callback()
+
+    monkeypatch.setitem(JOB_HANDLERS, JobType.PLAN_WEEK, handler)
+    monkeypatch.setattr("utils.workers.threading.Timer", InstantTimer)
+    pool.submit(JobType.PLAN_WEEK, attempts=3, backoff=1.5)
+    assert done.wait(1)
+    assert attempts["count"] == 3
+    assert delays == [1.5, 2.25]

--- a/utils/jobs.py
+++ b/utils/jobs.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from enum import Enum
+from typing import Any, Callable, Dict
+
+class JobType(str, Enum):
+    PLAN_WEEK = "plan_week"
+    SYNC_APP_EVENTS = "sync_app_events"
+
+JobHandler = Callable[[Any], None]
+
+JOB_HANDLERS: Dict[JobType, JobHandler] = {}
+
+def register(job_type: JobType) -> Callable[[JobHandler], JobHandler]:
+    """Decorator to register a function as a job handler."""
+    def decorator(func: JobHandler) -> JobHandler:
+        JOB_HANDLERS[job_type] = func
+        return func
+    return decorator
+
+@register(JobType.PLAN_WEEK)
+def plan_week(payload: Any) -> None:
+    """Placeholder planning job."""
+    pass
+
+@register(JobType.SYNC_APP_EVENTS)
+def sync_app_events(payload: Any) -> None:
+    """Placeholder sync job."""
+    pass

--- a/utils/workers.py
+++ b/utils/workers.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+from typing import Any
+from PyQt6.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal
+import threading
+import structlog
+
+from .jobs import JOB_HANDLERS, JobType
+
+class JobRunnable(QRunnable):
+    def __init__(self, pool: "WorkerPool", job_type: JobType, payload: Any, attempts: int, backoff: float, delay: float = 0.0):
+        super().__init__()
+        self.pool = pool
+        self.job_type = job_type
+        self.payload = payload
+        self.attempts = attempts
+        self.backoff = backoff
+        self.delay = delay
+
+    def run(self) -> None:
+        handler = JOB_HANDLERS.get(self.job_type)
+        if handler is None:
+            self.pool.logger.error("unknown_job", job_type=str(self.job_type))
+            return
+        try:
+            handler(self.payload)
+        except Exception as exc:  # pragma: no cover - error handling
+            self.pool.logger.error("job_error", job_type=str(self.job_type), exc=str(exc))
+            if self.attempts > 1:
+                next_delay = self.backoff if self.delay == 0 else self.delay * self.backoff
+                timer = threading.Timer(
+                    next_delay,
+                    lambda: self.pool.pool.start(
+                        JobRunnable(self.pool, self.job_type, self.payload, self.attempts - 1, self.backoff, next_delay)
+                    ),
+                )
+                timer.start()
+            else:
+                self.pool.job_failed.emit(self.job_type, self.payload, exc)
+
+class WorkerPool(QObject):
+    job_failed = pyqtSignal(object, object, object)
+
+    def __init__(self, logger: structlog.BoundLogger | None = None):
+        super().__init__()
+        self.pool = QThreadPool()
+        self.logger = logger or structlog.get_logger(__name__)
+
+    def submit(self, job_type: JobType, payload: Any = None, attempts: int = 3, backoff: float = 1.5) -> None:
+        runnable = JobRunnable(self, job_type, payload, attempts, backoff)
+        self.pool.start(runnable)
+
+worker_pool: WorkerPool | None = None
+
+def init_worker_pool(logger: structlog.BoundLogger | None = None) -> WorkerPool:
+    global worker_pool
+    if worker_pool is None:
+        worker_pool = WorkerPool(logger)
+    return worker_pool


### PR DESCRIPTION
## Summary
- Add job definitions for week planning and event syncing
- Introduce WorkerPool with retry and exponential backoff, plus global initializer
- Wire worker pool into development runner and expose `get_logger`
- Cover worker behaviour with new tests

## Testing
- `pytest tests/test_workers.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689a39f4ad40832ebca2ff740370e9fa