### PR TITLE
Milestone 3 — Micro-coaching nudges (backend)

### DIFF
--- a/agents/nudges.py
+++ b/agents/nudges.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+
+def generate_nudges(
+    planned_sessions: List[Dict],
+    tasks: List[Dict],
+    *,
+    max_sessions_per_day: int = 4,
+    now: datetime | None = None,
+) -> List[str]:
+    """Return up to three rule-based nudges.
+
+    Parameters
+    ----------
+    planned_sessions: List of scheduled study blocks.
+    tasks: Original tasks including tests with due dates.
+    max_sessions_per_day: Threshold for recommending spreading tasks.
+    now: Optional reference time for determinism in tests.
+    """
+    now = now or datetime.now()
+    nudges: List[str] = []
+
+    # Rule 1: Upcoming tests within 72h with less than 2h of study scheduled.
+    cutoff = now + timedelta(hours=72)
+    tests_due = [
+        t for t in tasks
+        if t.get("type") == "test"
+        and t.get("due_date")
+        and now <= t["due_date"] <= cutoff
+    ]
+    for test in tests_due:
+        course = test.get("course") or test.get("title")
+        study_minutes = 0
+        for sess in planned_sessions:
+            if sess.get("course") == course:
+                study_minutes += (sess["end_time"] - sess["start_time"]).total_seconds() / 60
+        if study_minutes < 120:
+            nudges.append(f"Add at least one 50-minute session for {course}.")
+        if len(nudges) >= 3:
+            return nudges[:3]
+
+    # Sessions scheduled today
+    today = now.date()
+    todays_sessions = [s for s in planned_sessions if s["start_time"].date() == today]
+
+    # Rule 2: Too many sessions today
+    if len(todays_sessions) > max_sessions_per_day:
+        task_title = todays_sessions[-1].get("title", "a task")
+        nudges.append(f"Consider spreading {task_title} to tomorrow.")
+        if len(nudges) >= 3:
+            return nudges[:3]
+
+    # Rule 3: Long day
+    if len(todays_sessions) >= 5:
+        nudges.append("Plan a 10-minute break after each session.")
+
+    return nudges[:3]

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -4,9 +4,11 @@ from typing import List, Dict, Tuple
 import os
 
 from integrations.google_calendar import GoogleCalendarClient
+from agents.nudges import generate_nudges
 
 
 ENABLE_LIVE_RESCHEDULE = os.getenv("ENABLE_LIVE_RESCHEDULE", "false").lower() == "true"
+ENABLE_MICRO_COACHING = os.getenv("ENABLE_MICRO_COACHING", "false").lower() == "true"
 
 
 def schedule_tasks(
@@ -81,6 +83,11 @@ def schedule_tasks(
                 start_time=start,
                 end_time=end,
             )
+
+    if ENABLE_MICRO_COACHING:
+        nudges = generate_nudges(scheduled, tasks)
+        return scheduled, nudges
+
     return scheduled
 
 

--- a/tests/test_nudges.py
+++ b/tests/test_nudges.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from datetime import datetime, timedelta, time
+import importlib
+
+from agents.nudges import generate_nudges
+
+
+NOW = datetime(2024, 1, 1, 9, 0)
+
+
+def make_session(start_offset_minutes: int, course: str | None = None, title: str | None = None):
+    start = NOW + timedelta(minutes=start_offset_minutes)
+    end = start + timedelta(minutes=50)
+    return {
+        'id': start_offset_minutes,
+        'title': title or f'Task {start_offset_minutes}',
+        'start_time': start,
+        'end_time': end,
+        'course': course,
+    }
+
+
+def test_nudge_for_upcoming_test():
+    tasks = [{
+        'id': 1,
+        'title': 'Math Exam',
+        'type': 'test',
+        'course': 'Math',
+        'due_date': NOW + timedelta(hours=48),
+    }]
+    planned = [make_session(0, course='Math')]
+    nudges = generate_nudges(planned, tasks, now=NOW)
+    assert "Add at least one 50-minute session for Math." in nudges
+
+
+def test_nudge_for_over_scheduled_day():
+    planned = [make_session(i * 60) for i in range(4)]
+    nudges = generate_nudges(planned, [], max_sessions_per_day=3, now=NOW)
+    assert nudges == ["Consider spreading Task 180 to tomorrow."]
+
+
+def test_nudge_for_long_day():
+    planned = [make_session(i * 60) for i in range(5)]
+    nudges = generate_nudges(planned, [], now=NOW)
+    assert "Plan a 10-minute break after each session." in nudges
+
+
+def test_planner_returns_nudges_when_enabled(monkeypatch):
+    monkeypatch.setenv('ENABLE_MICRO_COACHING', 'true')
+    import agents.planner as planner
+    importlib.reload(planner)
+    tasks = [
+        {'id': i, 'title': f'Task {i}', 'type': 'study', 'estimated_duration': 50, 'due_date': None}
+        for i in range(5)
+    ]
+    scheduled, nudges = planner.schedule_tasks(tasks, [], work_start=time(9, 0), work_end=time(15, 0))
+    assert "Plan a 10-minute break after each session." in nudges
+    monkeypatch.delenv('ENABLE_MICRO_COACHING', raising=False)
+    importlib.reload(planner)


### PR DESCRIPTION
## Summary
- Add rule-based micro-coaching nudge generator to suggest breaks, spread sessions, and study for upcoming tests.
- Hook planner to return nudges when `ENABLE_MICRO_COACHING` flag is set.
- Cover nudge rules and planner integration with unit tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4016f474832e9d2ca05f1197c886