### PR TITLE
feat: add calendar dnd conflicts

### DIFF
--- a/migrations/versions/0006_calendar_indexes.py
+++ b/migrations/versions/0006_calendar_indexes.py
@@ -1,0 +1,27 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = '0006_calendar_indexes'
+down_revision = '0005_app_owned_event_meta'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS idx_events_start_end ON events(start_time, end_time)"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_start_end ON tasks(start_time, end_time)"
+        )
+    )
+
+
+def downgrade():
+    op.execute(text("DROP INDEX IF EXISTS idx_events_start_end"))
+    op.execute(text("DROP INDEX IF EXISTS idx_tasks_start_end"))

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+from ui.calendar.conflicts import TimeRange, find_conflicts
+
+
+BASE = datetime(2024, 1, 1)
+
+def tr(start_hour: int, end_hour: int) -> TimeRange:
+    return TimeRange(BASE + timedelta(hours=start_hour), BASE + timedelta(hours=end_hour))
+
+
+def test_edge_touching_not_conflict():
+    ranges = [tr(8, 9), tr(9, 10)]
+    assert find_conflicts(ranges) == []
+
+
+def test_simple_conflict_pair():
+    ranges = [tr(9, 11), tr(10, 12), tr(12, 13)]
+    assert find_conflicts(ranges) == [(0, 1)]
+
+
+def test_multiple_conflicts_chain():
+    ranges = [tr(9, 11), tr(10, 12), tr(11, 13), tr(12, 14)]
+    assert find_conflicts(ranges) == [(0, 1), (1, 2), (2, 3)]

--- a/ui/calendar/conflicts.py
+++ b/ui/calendar/conflicts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Tuple
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    """Simple start/end container used for conflict detection."""
+    start: datetime
+    end: datetime
+
+    def overlaps(self, other: "TimeRange") -> bool:
+        """Return True if two ranges overlap.
+
+        Endpoints touching (end == start) do not count as a conflict.
+        """
+        return self.start < other.end and other.start < self.end
+
+
+def find_conflicts(ranges: Iterable[TimeRange]) -> List[Tuple[int, int]]:
+    """Return index pairs of overlapping ranges.
+
+    The returned list is sorted in the order the conflicts are discovered.
+    Each pair represents the indexes of two ranges that overlap.
+    """
+    items = list(ranges)
+    conflicts: List[Tuple[int, int]] = []
+    for i, a in enumerate(items):
+        for j in range(i + 1, len(items)):
+            if a.overlaps(items[j]):
+                conflicts.append((i, j))
+    return conflicts

--- a/ui/calendar/week_view.py
+++ b/ui/calendar/week_view.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta
 from typing import Dict
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem
-from PyQt6.QtCore import Qt, QDate, QTime
+from PyQt6.QtCore import Qt, QDate, QTime, QEvent
 from sqlalchemy.engine import Engine
 
 from .calendar_model import CalendarModel, CalendarItem
 from .month_view import MonthView
 from .quick_add_dialog import QuickAddDialog
+from .conflicts import TimeRange, find_conflicts
 
 
 class WeekView(QWidget):
@@ -20,6 +21,9 @@ class WeekView(QWidget):
         self.current_day = datetime.now().date()
         self.selected_item: CalendarItem | None = None
         self._cell_items: Dict[tuple[int, int], CalendarItem] = {}
+        self._drag_item: CalendarItem | None = None
+        self._drag_start: tuple[int, int] | None = None
+        self._resize_edge: str | None = None
 
         layout = QVBoxLayout(self)
         self.month = MonthView(self)
@@ -33,6 +37,8 @@ class WeekView(QWidget):
         self.table.verticalHeader().setDefaultSectionSize(40)
         self.table.horizontalHeader().setDefaultSectionSize(120)
         self.table.cellClicked.connect(self.on_cell_clicked)
+        self.table.setMouseTracking(True)
+        self.table.viewport().installEventFilter(self)
         layout.addWidget(self.table, 1)
 
         # apply local styles
@@ -66,14 +72,21 @@ class WeekView(QWidget):
             self.table.setHorizontalHeaderItem(col, QTableWidgetItem((week_start + timedelta(days=col)).strftime("%a %d")))
         for day, items in items_by_day.items():
             col = (day - week_start).days
-            for item in items:
+            ranges = [TimeRange(i.start, i.end) for i in items]
+            conflicts = find_conflicts(ranges)
+            conflicted = {i for pair in conflicts for i in pair}
+            for idx, item in enumerate(items):
                 row = item.start.hour
                 cell = self.table.item(row, col)
                 text = item.title
                 if cell:
                     cell.setText(cell.text() + " / " + text)
                 else:
-                    self.table.setItem(row, col, QTableWidgetItem(text))
+                    cell = QTableWidgetItem(text)
+                    self.table.setItem(row, col, cell)
+                if idx in conflicted:
+                    cell.setBackground(Qt.red)
+                    cell.setToolTip("Overlaps with another item")
                 self._cell_items[(row, col)] = item
         # update month badges for current month
         month_start = date(self.current_day.year, self.current_day.month, 1)
@@ -94,8 +107,12 @@ class WeekView(QWidget):
             self.open_quick_add()
             return
         if key == Qt.Key_Delete and self.selected_item:
-            self.model.delete_item(self.selected_item)
-            self.refresh()
+            if (
+                self.selected_item.table == "events"
+                and self.selected_item.source == "app"
+            ):
+                self.model.delete_item(self.selected_item)
+                self.refresh()
             return
         if key == Qt.Key_E and self.selected_item:
             self.edit_selected()
@@ -131,3 +148,53 @@ class WeekView(QWidget):
             # simple approach: delete old and rely on dialog insert
             self.model.delete_item(self.selected_item)
             self.refresh()
+
+    # ----- drag & drop / resize -----
+    def eventFilter(self, source, event):  # type: ignore[override]
+        if source is self.table.viewport():
+            if event.type() == QEvent.MouseButtonPress:
+                pos = event.position().toPoint()
+                row = self.table.rowAt(pos.y())
+                col = self.table.columnAt(pos.x())
+                item = self._cell_items.get((row, col))
+                if not item:
+                    return False
+                self.selected_item = item
+                self._drag_item = item
+                self._drag_start = (row, col)
+                rect = self.table.visualRect(self.table.model().index(row, col))
+                margin = 5
+                if abs(pos.y() - rect.top()) <= margin:
+                    self._resize_edge = "start"
+                elif abs(pos.y() - rect.bottom()) <= margin:
+                    self._resize_edge = "end"
+                else:
+                    self._resize_edge = None
+                return True
+            if event.type() == QEvent.MouseButtonRelease and self._drag_item:
+                pos = event.position().toPoint()
+                row = self.table.rowAt(pos.y())
+                col = self.table.columnAt(pos.x())
+                if row < 0 or col < 0 or self._drag_start is None:
+                    self._drag_item = None
+                    self._resize_edge = None
+                    return False
+                drow = row - self._drag_start[0]
+                dcol = col - self._drag_start[1]
+                start = self._drag_item.start
+                end = self._drag_item.end
+                if self._resize_edge == "start":
+                    new_start = start + timedelta(days=dcol, hours=drow)
+                    new_end = end
+                elif self._resize_edge == "end":
+                    new_start = start
+                    new_end = end + timedelta(days=dcol, hours=drow)
+                else:
+                    new_start = start + timedelta(days=dcol, hours=drow)
+                    new_end = end + timedelta(days=dcol, hours=drow)
+                self.model.update_item_time(self._drag_item, new_start, new_end)
+                self._drag_item = None
+                self._resize_edge = None
+                self.refresh()
+                return True
+        return super().eventFilter(source, event)


### PR DESCRIPTION
## Summary
- add drag & drop with resize to week view and guard deletions
- add conflict detection logic and highlight overlapping items
- add pure conflict detection module with tests and optional DB indexes

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `pytest tests/test_conflicts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a4fe325c0832e85bc93ba32d6ac3e