### PR TITLE
feat: inline quick-add parsing and hover cards

### DIFF
--- a/agents/classifier.py
+++ b/agents/classifier.py
@@ -9,7 +9,7 @@ COURSE_PATTERN = re.compile(r"\b([A-Za-z]{2,}[\s-]?\d{2,3})\b")
 # Ordered list of (pattern, type, priority)
 RULES = [
     (re.compile(r"\b(exam|midterm|final|quiz)\b"), "test", 1),
-    (re.compile(r"\b(homework|assignment|worksheet)\b"), "homework", 2),
+    (re.compile(r"\b(homework|assignment|worksheet|hw)\b"), "homework", 2),
     (re.compile(r"\b(project|capstone|milestone)\b"), "project", 2),
     (re.compile(r"\b(class|lecture|seminar)\b"), "class", 3),
     (re.compile(r"\b(meet|meeting)\b"), "meeting", 3),
@@ -27,6 +27,16 @@ def _extract_course_label(text: str) -> Optional[str]:
         # Normalize by removing spaces and hyphens
         return re.sub(r"[\s-]", "", match.group(1)).upper()
     return None
+
+
+def extract_course_label(text: str) -> Optional[str]:
+    """Public helper to fetch a normalized course label from text.
+
+    This wraps the internal ``_extract_course_label`` function so that other
+    modules can reuse the same logic without depending on a private helper.
+    The existing ``classify`` API remains unchanged.
+    """
+    return _extract_course_label(text)
 
 
 def classify(title: str, description: str = "", use_llm: bool = False) -> Dict[str, Optional[str] | int]:

--- a/tests/test_quickadd_parse.py
+++ b/tests/test_quickadd_parse.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from ui.calendar.quick_add_inline import parse_inline
+
+
+def test_parse_hw_example():
+    base = datetime(2024, 1, 1, 9, 0)  # Monday
+    result = parse_inline("Math HW 30m @ Tue 3pm #MATH203", base)
+    assert result["title"] == "Math HW"
+    assert result["start"] == datetime(2024, 1, 2, 15, 0)
+    assert result["end"] == datetime(2024, 1, 2, 15, 30)
+    assert result["type"] == "homework"
+    assert result["course"] == "MATH203"
+
+
+def test_parse_study_example():
+    base = datetime(2024, 1, 1, 9, 0)
+    result = parse_inline("Study BIO210 50m tomorrow 10:00", base)
+    assert result["title"] == "Study BIO210"
+    assert result["start"] == datetime(2024, 1, 2, 10, 0)
+    assert result["end"] == datetime(2024, 1, 2, 10, 50)
+    assert result["type"] == "study"
+    assert result["course"] == "BIO210"

--- a/ui/calendar/hover_card.py
+++ b/ui/calendar/hover_card.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from PyQt6.QtWidgets import QFrame, QLabel, QVBoxLayout
+from PyQt6.QtCore import Qt, QPoint
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from .calendar_model import CalendarItem
+
+
+class HoverCard(QFrame):
+    """Small floating card shown when hovering over a calendar item."""
+
+    def __init__(self, engine: Engine, parent=None):
+        super().__init__(parent, Qt.ToolTip)
+        self.engine = engine
+        self.setWindowFlags(Qt.ToolTip)
+        layout = QVBoxLayout(self)
+        self.label = QLabel("", self)
+        layout.addWidget(self.label)
+        self.setStyleSheet("background:#ffffe1; border:1px solid gray;")
+
+    def show_item(self, item: CalendarItem, conflict: bool = False, pos: QPoint | None = None) -> None:
+        lines = [item.title]
+        course = None
+        due = None
+        if item.table == "tasks":
+            with self.engine.begin() as conn:
+                row = conn.execute(
+                    text("SELECT course_label, due_date FROM tasks WHERE id=:id"),
+                    {"id": item.id},
+                ).first()
+            if row:
+                course = row.course_label
+                due = row.due_date
+        line2 = item.type
+        if course:
+            line2 += f" / {course}"
+        lines.append(line2)
+        lines.append(f"{item.start.strftime('%H:%M')} - {item.end.strftime('%H:%M')}")
+        if conflict:
+            lines.append("Conflicts")
+        if due:
+            try:
+                due_dt = datetime.fromisoformat(due)
+                lines.append(f"Due {due_dt.date().isoformat()}")
+            except Exception:
+                pass
+        self.label.setText("\n".join(lines))
+        self.adjustSize()
+        if pos is not None:
+            self.move(pos)
+        self.show()
+
+    def hide_card(self) -> None:
+        self.hide()

--- a/ui/calendar/quick_add_inline.py
+++ b/ui/calendar/quick_add_inline.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, time, date
+from uuid import uuid4
+from typing import Optional, Dict, Any
+
+try:  # pragma: no cover - used only when Qt is installed
+    from PyQt6.QtWidgets import QLineEdit
+    from PyQt6.QtCore import Qt, pyqtSignal, QRect
+    QT_AVAILABLE = True
+except Exception:  # pragma: no cover - allows parser tests without Qt libs
+    QT_AVAILABLE = False
+
+    class QLineEdit:  # type: ignore
+        pass
+
+    def pyqtSignal(*args, **kwargs):  # type: ignore
+        class _DummySignal:
+            def connect(self, *a, **k):
+                pass
+
+            def emit(self, *a, **k):
+                pass
+
+        return _DummySignal()
+
+    class QRect:  # type: ignore
+        pass
+
+    class Qt:  # type: ignore
+        pass
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from agents import classifier
+
+# ----- parsing helpers -----
+WEEKDAYS = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+TIME_PATTERN = re.compile(r"\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b", re.IGNORECASE)
+DURATION_PATTERN = re.compile(r"(\d+)\s*(h|m)", re.IGNORECASE)
+
+
+def _next_weekday(start: date, target: int) -> date:
+    days_ahead = target - start.weekday()
+    if days_ahead <= 0:
+        days_ahead += 7
+    return start + timedelta(days=days_ahead)
+
+
+def parse_inline(text: str, default_start: datetime) -> Dict[str, Any]:
+    """Parse a quick-add inline string."""
+    remaining = text.strip()
+    had_at = "@" in remaining
+    course: Optional[str] = None
+
+    # extract course label. If preceded by '#', remove it from title
+    explicit_course = re.search(r"#([A-Za-z0-9-]+)", remaining)
+    if explicit_course:
+        c = classifier.extract_course_label(explicit_course.group(1))
+        if c:
+            course = c
+            remaining = remaining.replace(explicit_course.group(0), "")
+    else:
+        c = classifier.extract_course_label(remaining)
+        if c:
+            course = c
+
+    # duration
+    duration = 60  # default 1h
+    m = DURATION_PATTERN.search(remaining)
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).lower()
+        duration = amount * 60 if unit == "h" else amount
+        remaining = remaining[: m.start()] + remaining[m.end() :]
+
+    # date/time portion
+    day = default_start.date()
+    tm = default_start.time()
+    dt_part = ""
+    if "@" in remaining:
+        remaining, dt_part = remaining.split("@", 1)
+    else:
+        dt_part = remaining
+    if re.search(r"\btomorrow\b", dt_part, re.IGNORECASE):
+        day = default_start.date() + timedelta(days=1)
+        dt_part = re.sub(r"\btomorrow\b", "", dt_part, flags=re.IGNORECASE)
+    for name, idx in WEEKDAYS.items():
+        if re.search(rf"\b{name}\b", dt_part, re.IGNORECASE):
+            day = _next_weekday(default_start.date(), idx)
+            dt_part = re.sub(rf"\b{name}\b", "", dt_part, flags=re.IGNORECASE)
+            break
+    tm_match = TIME_PATTERN.search(dt_part)
+    if tm_match:
+        hour = int(tm_match.group(1))
+        minute = int(tm_match.group(2) or 0)
+        ampm = tm_match.group(3)
+        if ampm:
+            ampm = ampm.lower()
+            if ampm == "pm" and hour < 12:
+                hour += 12
+            if ampm == "am" and hour == 12:
+                hour = 0
+        tm = time(hour, minute)
+        dt_part = dt_part[: tm_match.start()] + dt_part[tm_match.end() :]
+    if not had_at:
+        remaining = dt_part
+    start_dt = datetime.combine(day, tm)
+    end_dt = start_dt + timedelta(minutes=duration)
+
+    # title cleanup
+    title = re.sub(r"\s+", " ", remaining).strip()
+
+    cls = classifier.classify(title)
+    item_type = cls["type"]
+    course = course or cls["course_label"]
+
+    return {
+        "title": title,
+        "start": start_dt,
+        "end": end_dt,
+        "type": item_type,
+        "course": course,
+    }
+
+
+# ----- widget -----
+class QuickAddInline(QLineEdit):
+    """Inline quick-add entry displayed over the calendar grid."""
+
+    saved = pyqtSignal()
+
+    def __init__(self, engine: Engine, parent=None):
+        super().__init__(parent)
+        self.engine = engine
+        self._default_start = datetime.now()
+        self.hide()
+        self.returnPressed.connect(self.commit)
+
+    def start(self, rect, default_start: datetime) -> None:
+        if isinstance(rect, QRect):
+            self.setGeometry(rect)
+        else:
+            self.setGeometry(rect)
+        self._default_start = default_start
+        self.clear()
+        self.show()
+        self.setFocus()
+
+    def commit(self) -> None:
+        text = self.text().strip()
+        if not text:
+            self.hide()
+            return
+        data = parse_inline(text, self._default_start)
+        if data["type"] in {"meeting", "class"}:
+            with self.engine.begin() as conn:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO events (source, source_id, title, start_time, end_time, type, description)
+                        VALUES (:source, :source_id, :title, :start, :end, :type, '')
+                        """
+                    ),
+                    {
+                        "source": "app",
+                        "source_id": uuid4().hex,
+                        "title": data["title"],
+                        "start": data["start"].isoformat(),
+                        "end": data["end"].isoformat(),
+                        "type": data["type"],
+                    },
+                )
+        else:
+            duration = int((data["end"] - data["start"]).total_seconds() // 60)
+            with self.engine.begin() as conn:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO tasks (title, type, estimated_duration, due_date, course_label, start_time, end_time)
+                        VALUES (:title, :type, :est, NULL, :label, :start, :end)
+                        """
+                    ),
+                    {
+                        "title": data["title"],
+                        "type": data["type"],
+                        "est": duration,
+                        "label": data["course"],
+                        "start": data["start"].isoformat(),
+                        "end": data["end"].isoformat(),
+                    },
+                )
+        self.hide()
+        self.saved.emit()


### PR DESCRIPTION
## Summary
- add inline quick-add parser and widget
- display hover cards for calendar blocks
- extend classifier with public course label helper
- test parser for inline quick-add examples

## Testing
- `pytest tests/test_quickadd_parse.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5605fe18832e971a5d2b65a9d494