### PR TITLE
feat: add ADHD mode plus plus widgets

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     app_env: str = "development"
     app_log_level: str = "INFO"
     enable_dark_mode: bool = False
+    enable_adhd_mode: bool = False
+    preferred_timer_mode: str = "25/5"
 
     # Keyboard shortcuts (defaults)
     shortcut_new_item: str = "N"

--- a/tests/test_timer_engine.py
+++ b/tests/test_timer_engine.py
@@ -1,0 +1,20 @@
+from utils.timers import TimerEngine
+
+
+import pytest
+
+
+@pytest.mark.parametrize("mode,work,break_", [("25/5", 25*60, 5*60), ("50/10", 50*60, 10*60)])
+def test_timer_transitions(mode, work, break_):
+    engine = TimerEngine(mode)
+    engine.start()
+    assert engine.phase == "work"
+    assert engine.remaining == work
+    for _ in range(work):
+        engine.tick_manual()
+    assert engine.phase == "break"
+    assert engine.remaining == break_
+    for _ in range(break_):
+        engine.tick_manual()
+    assert engine.phase == "work"
+    assert engine.remaining == work

--- a/ui/adhd/focus_timeline.py
+++ b/ui/adhd/focus_timeline.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt6.QtCore import Qt
+
+
+class FocusTimeline(QWidget):
+    """Simple timeline showing the current and next three sessions."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        title = QLabel("Focus Timeline")
+        title.setStyleSheet("font-size: 18px; font-weight: bold;")
+        layout.addWidget(title)
+        self.blocks: list[QLabel] = []
+        for _ in range(4):
+            lbl = QLabel("–")
+            lbl.setStyleSheet("font-size: 16px; padding: 8px;")
+            layout.addWidget(lbl)
+            self.blocks.append(lbl)
+
+    def set_sessions(self, sessions: list[str]) -> None:
+        for i, text in enumerate(sessions[:4]):
+            self.blocks[i].setText(text)
+        for j in range(len(sessions), 4):
+            self.blocks[j].setText("–")

--- a/ui/adhd/one_thing_now.py
+++ b/ui/adhd/one_thing_now.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QHBoxLayout
+from PyQt6.QtCore import Qt
+
+
+class OneThingNow(QWidget):
+    """Displays the current task with basic controls."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.label = QLabel("One thing now")
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.label.setStyleSheet("font-size: 20px; padding: 16px;")
+        layout.addWidget(self.label)
+
+        controls = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        controls.addWidget(self.start_btn)
+        self.pause_btn = QPushButton("Pause")
+        controls.addWidget(self.pause_btn)
+        self.skip_btn = QPushButton("Skip")
+        controls.addWidget(self.skip_btn)
+        layout.addLayout(controls)

--- a/ui/adhd/timer_widget.py
+++ b/ui/adhd/timer_widget.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QComboBox, QHBoxLayout
+from PyQt6.QtCore import Qt
+from utils.timers import TimerEngine
+
+
+class TimerWidget(QWidget):
+    """UI wrapper around :class:`TimerEngine` with controls."""
+
+    def __init__(self, settings, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.settings = settings
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.label = QLabel("00:00")
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.label.setStyleSheet("font-size: 32px; padding: 16px;")
+        layout.addWidget(self.label)
+
+        controls = QHBoxLayout()
+        self.mode_box = QComboBox()
+        self.mode_box.addItems(["25/5", "50/10"])
+        if getattr(settings, "preferred_timer_mode", "25/5") == "50/10":
+            self.mode_box.setCurrentText("50/10")
+        controls.addWidget(self.mode_box)
+
+        self.start_btn = QPushButton("Start")
+        controls.addWidget(self.start_btn)
+        self.pause_btn = QPushButton("Pause")
+        controls.addWidget(self.pause_btn)
+        self.skip_btn = QPushButton("Skip")
+        controls.addWidget(self.skip_btn)
+        layout.addLayout(controls)
+
+        self.engine = TimerEngine(self.mode_box.currentText())
+        self.engine.tick.connect(self.update_label)
+        self.mode_box.currentTextChanged.connect(self.change_mode)
+        self.start_btn.clicked.connect(self.engine.start)
+        self.pause_btn.clicked.connect(self.engine.pause)
+        self.skip_btn.clicked.connect(self.engine.skip)
+
+    def change_mode(self, mode: str) -> None:
+        self.engine.set_mode(mode)
+        if hasattr(self.settings, "preferred_timer_mode"):
+            self.settings.preferred_timer_mode = mode
+
+    def update_label(self, remaining: int) -> None:
+        minutes = remaining // 60
+        seconds = remaining % 60
+        self.label.setText(f"{minutes:02d}:{seconds:02d}")

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from PyQt6.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QStackedWidget
+from PyQt6.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QStackedWidget, QVBoxLayout
 from project.settings import Settings, load_settings
 from project.db import get_engine, ensure_db
 from integrations.auth_supabase import SupabaseAuth
@@ -56,7 +56,24 @@ class MainWindow(QMainWindow):
             self.stack.addWidget(self.pages[key])
 
         root.addWidget(self.sidebar)
-        root.addWidget(self.stack, 1)
+
+        if self.settings.enable_adhd_mode:
+            from ui.adhd.timer_widget import TimerWidget
+            from ui.adhd.focus_timeline import FocusTimeline
+            from ui.adhd.one_thing_now import OneThingNow
+
+            self.sidebar.hide()
+            panel = QWidget(self)
+            panel_layout = QVBoxLayout(panel)
+            self.timer_widget = TimerWidget(self.settings, self)
+            self.one_thing_now = OneThingNow(self)
+            self.focus_timeline = FocusTimeline(self)
+            panel_layout.addWidget(self.timer_widget)
+            panel_layout.addWidget(self.one_thing_now)
+            panel_layout.addWidget(self.focus_timeline)
+            root.addWidget(panel, 1)
+        else:
+            root.addWidget(self.stack, 1)
 
         self.setCentralWidget(container)
 

--- a/utils/timers.py
+++ b/utils/timers.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal
+
+
+class TimerEngine(QObject):
+    """Simple Pomodoro-like timer engine based on QTimer.
+
+    Supports two modes: "25/5" and "50/10" where the numbers denote
+    work and break durations in minutes. The engine emits signals on
+    phase transitions and every tick. Designed to avoid blocking the UI
+    thread; QTimer drives the countdown.
+    """
+
+    tick = pyqtSignal(int)  # remaining seconds
+    session_started = pyqtSignal()
+    session_finished = pyqtSignal()
+    break_started = pyqtSignal()
+    break_finished = pyqtSignal()
+
+    def __init__(self, mode: str = "25/5", parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self.mode = mode
+        self.work_duration, self.break_duration = self._durations_for_mode(mode)
+        self.phase: str = "idle"  # "work", "break", "idle"
+        self.remaining: int = 0
+        self.timer = QTimer(self)
+        self.timer.setInterval(1000)
+        self.timer.timeout.connect(self._tick)
+
+    def _durations_for_mode(self, mode: str) -> tuple[int, int]:
+        if mode == "50/10":
+            return 50 * 60, 10 * 60
+        # default to 25/5
+        return 25 * 60, 5 * 60
+
+    def set_mode(self, mode: str) -> None:
+        self.mode = mode
+        self.work_duration, self.break_duration = self._durations_for_mode(mode)
+
+    def start(self) -> None:
+        """Begin a work session."""
+        self.phase = "work"
+        self.remaining = self.work_duration
+        self.session_started.emit()
+        self.tick.emit(self.remaining)
+        self.timer.start()
+
+    def pause(self) -> None:
+        self.timer.stop()
+
+    def resume(self) -> None:
+        if self.phase != "idle":
+            self.timer.start()
+
+    def skip(self) -> None:
+        """Skip the current phase immediately."""
+        self.remaining = 0
+        self._tick()  # force transition
+
+    # Exposed for tests to advance time manually
+    def tick_manual(self) -> None:
+        self._tick()
+
+    def _tick(self) -> None:
+        if self.phase == "idle":
+            return
+        self.remaining -= 1
+        if self.remaining <= 0:
+            if self.phase == "work":
+                self.session_finished.emit()
+                self.phase = "break"
+                self.remaining = self.break_duration
+                self.break_started.emit()
+            elif self.phase == "break":
+                self.break_finished.emit()
+                self.phase = "work"
+                self.remaining = self.work_duration
+                self.session_started.emit()
+        self.tick.emit(self.remaining)


### PR DESCRIPTION
## Summary
- add QTimer-based timer engine with work/break transitions
- introduce ADHD mode widgets: timer control, one thing now, focus timeline
- gate ADHD mode panel behind `enable_adhd_mode` feature flag and persist preferred timer

## Testing
- `pytest tests/test_timer_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5860b720832e8c0173c829300979