### PR TITLE
Harden Google Calendar sync with conflict resolution

### DIFF
--- a/migrations/versions/0007_sync_etags_and_stamps.py
+++ b/migrations/versions/0007_sync_etags_and_stamps.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = '0007_sync_etags_and_stamps'
+down_revision = '0006_calendar_indexes'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('events') as batch:
+        batch.add_column(sa.Column('etag', sa.String(), nullable=True))
+        batch.add_column(sa.Column('updated_at', sa.String(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')))
+        batch.add_column(sa.Column('last_synced_at', sa.String(), nullable=True))
+    with op.batch_alter_table('staging_events') as batch:
+        batch.add_column(sa.Column('etag', sa.String(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('staging_events') as batch:
+        batch.drop_column('etag')
+    with op.batch_alter_table('events') as batch:
+        batch.drop_column('last_synced_at')
+        batch.drop_column('updated_at')
+        batch.drop_column('etag')

--- a/project/db_merge.py
+++ b/project/db_merge.py
@@ -1,65 +1,116 @@
 from __future__ import annotations
 from typing import Dict, Any, Optional
 from datetime import datetime
+import structlog
 from sqlalchemy import text
 
 
 def _norm_event(event: Dict[str, Any]) -> Dict[str, Any]:
     payload: Dict[str, Any] = {}
-    for key in ["source", "source_id", "title", "start_time", "end_time", "type", "description"]:
+    for key in [
+        "source",
+        "source_id",
+        "title",
+        "start_time",
+        "end_time",
+        "type",
+        "description",
+        "etag",
+        "updated_at",
+    ]:
+        if key not in event:
+            continue
         val = event.get(key)
         if key in ("start_time", "end_time") and isinstance(val, datetime):
+            payload[key] = val.isoformat()
+        elif key == "updated_at" and isinstance(val, datetime):
             payload[key] = val.isoformat()
         else:
             payload[key] = val
     return payload
 
 
-def merge_event(conn, event: Dict[str, Any]) -> int:
+def merge_event(conn, event: Dict[str, Any], logger: Optional[structlog.BoundLogger] = None) -> int:
     """Insert or update an event record and return its id.
 
-    Deduplicate by (source, source_id) if present. As a fallback, deduplicate
-    by (title, start_time).
+    Conflict policy:
+        - If the local row was edited after the last sync and the remote version
+          changed, keep the remote update but create a local "conflict" copy of
+          the unsynced changes.
+        - Otherwise, whichever side has the newer ``updated_at`` wins.
     """
+    logger = logger or structlog.get_logger(__name__)
     payload = _norm_event(event)
     lookup = {"source": payload["source"], "source_id": payload["source_id"]}
     row = conn.execute(
-        text("SELECT id FROM events WHERE source = :source AND source_id = :source_id"),
+        text(
+            "SELECT id, title, start_time, end_time, type, description, etag, updated_at, last_synced_at "
+            "FROM events WHERE source = :source AND source_id = :source_id"
+        ),
         lookup,
     ).fetchone()
+    now = datetime.utcnow().isoformat()
+    remote_updated = payload.get("updated_at", now)
+    remote_etag = payload.get("etag")
     if row:
         event_id = int(row.id if hasattr(row, "id") else row[0])
-        conn.execute(
-            text(
-                "UPDATE events SET title=:title, start_time=:start_time, end_time=:end_time, "
-                "type=:type, description=:description WHERE id=:id"
-            ),
-            {**payload, "id": event_id},
-        )
+        local_updated = row.updated_at if hasattr(row, "updated_at") else row[7]
+        last_synced = row.last_synced_at if hasattr(row, "last_synced_at") else row[8]
+        local_edited = bool(last_synced and local_updated and local_updated > last_synced)
+        remote_changed = bool(last_synced is None or remote_updated > last_synced)
+        if local_edited and remote_changed:
+            conflict_payload = {
+                "source": "local",
+                "source_id": f"conflict-{event_id}",
+                "title": f"{row.title} (conflict)",
+                "start_time": row.start_time,
+                "end_time": row.end_time,
+                "type": row.type,
+                "description": row.description,
+                "updated_at": local_updated,
+            }
+            conn.execute(
+                text(
+                    "INSERT INTO events (source, source_id, title, start_time, end_time, type, description, updated_at) "
+                    "VALUES (:source, :source_id, :title, :start_time, :end_time, :type, :description, :updated_at)"
+                ),
+                conflict_payload,
+            )
+            logger.warning("sync_conflict", source_id=lookup["source_id"])
+        keep_remote = not local_edited or remote_updated >= local_updated
+        if keep_remote:
+            conn.execute(
+                text(
+                    "UPDATE events SET title=:title, start_time=:start_time, end_time=:end_time, "
+                    "type=:type, description=:description, etag=:etag, updated_at=:updated_at, last_synced_at=:last_synced_at "
+                    "WHERE id=:id"
+                ),
+                {
+                    **payload,
+                    "etag": remote_etag,
+                    "updated_at": remote_updated,
+                    "last_synced_at": now,
+                    "id": event_id,
+                },
+            )
+        else:
+            conn.execute(
+                text(
+                    "UPDATE events SET last_synced_at=:last_synced_at WHERE id=:id"
+                ),
+                {"last_synced_at": now, "id": event_id},
+            )
         return event_id
-    # Fallback dedupe by title + start_time
-    row = conn.execute(
-        text("SELECT id FROM events WHERE title = :title AND start_time = :start_time"),
-        {"title": payload["title"], "start_time": payload["start_time"]},
-    ).fetchone()
-    if row:
-        event_id = int(row.id if hasattr(row, "id") else row[0])
-        conn.execute(
-            text(
-                "UPDATE events SET source=:source, source_id=:source_id, end_time=:end_time, "
-                "type=:type, description=:description WHERE id=:id"
-            ),
-            {**payload, "id": event_id},
-        )
-        return event_id
-    # Insert new
-    conn.execute(
-        text(
-            "INSERT INTO events (source, source_id, title, start_time, end_time, type, description) "
-            "VALUES (:source, :source_id, :title, :start_time, :end_time, :type, :description)"
-        ),
-        payload,
-    )
+    # No existing row: insert
+    insert_payload = {
+        **payload,
+        "etag": remote_etag,
+        "updated_at": remote_updated,
+        "last_synced_at": now,
+    }
+    cols = ", ".join(insert_payload.keys())
+    binds = ", ".join(f":{k}" for k in insert_payload.keys())
+    conn.execute(text(f"INSERT INTO events ({cols}) VALUES ({binds})"), insert_payload)
     event_id = conn.execute(text("SELECT last_insert_rowid() AS id")).scalar_one()
     return int(event_id)
 

--- a/tests/test_sync_policies.py
+++ b/tests/test_sync_policies.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+
+from project.db import get_engine
+from project.db_merge import merge_event
+from integrations.google_calendar import GoogleCalendarClient
+
+
+def run_migrations(db_path: Path) -> None:
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+    cfg.set_main_option("script_location", str(Path(__file__).resolve().parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, "head")
+
+
+def setup_engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    run_migrations(db_path)
+    return get_engine(str(db_path))
+
+
+def test_conflict_policy_creates_copy(tmp_path, caplog):
+    engine = setup_engine(tmp_path)
+    client = GoogleCalendarClient(engine)
+    base_start = "2024-01-01T09:00:00"
+    base_end = "2024-01-01T10:00:00"
+    now = datetime.utcnow()
+    earlier = (now - timedelta(days=1)).isoformat()
+    later = (now + timedelta(days=1)).isoformat()
+    # initial remote insert with older timestamp
+    with engine.begin() as conn:
+        merge_event(
+            conn,
+            {
+                "source": "google",
+                "source_id": "ev1",
+                "title": "Original",
+                "start_time": base_start,
+                "end_time": base_end,
+                "type": "meeting",
+                "description": "",
+                "updated_at": earlier,
+                "etag": "v1",
+            },
+        )
+    # local edit after sync
+    with engine.begin() as conn:
+        eid = conn.execute(text("SELECT id FROM events WHERE source='google'"))
+        event_id = int(eid.scalar_one())
+    client.upsert_event(event_id, {"title": "Local edit"})
+    # remote change after local edit triggers conflict
+    with engine.begin() as conn:
+        merge_event(
+            conn,
+            {
+                "source": "google",
+                "source_id": "ev1",
+                "title": "Remote edit",
+                "start_time": base_start,
+                "end_time": base_end,
+                "type": "meeting",
+                "description": "",
+                "updated_at": later,
+                "etag": "v2",
+            },
+        )
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text("SELECT title, source, source_id, etag, last_synced_at FROM events ORDER BY id")
+        ).fetchall()
+    assert len(rows) == 2
+    titles = {r[0] for r in rows}
+    assert "Remote edit" in titles
+    assert "Local edit (conflict)" in titles
+    remote_row = next(r for r in rows if r[0] == "Remote edit")
+    assert remote_row[3] == "v2"
+    assert remote_row[4] is not None
+    # re-merge should be idempotent
+    with engine.begin() as conn:
+        merge_event(
+            conn,
+            {
+                "source": "google",
+                "source_id": "ev1",
+                "title": "Remote edit",
+                "start_time": base_start,
+                "end_time": base_end,
+                "type": "meeting",
+                "description": "",
+                "updated_at": "2024-01-02T08:00:00",
+                "etag": "v2",
+            },
+        )
+    with engine.begin() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM events")).scalar_one()
+    assert count == 2

--- a/utils/jobs.py
+++ b/utils/jobs.py
@@ -24,5 +24,17 @@ def plan_week(payload: Any) -> None:
 
 @register(JobType.SYNC_APP_EVENTS)
 def sync_app_events(payload: Any) -> None:
-    """Placeholder sync job."""
-    pass
+    """Background job to sync application events.
+
+    ``payload`` expects a ``client`` key containing an instance of
+    :class:`integrations.google_calendar.GoogleCalendarClient`.  The client is
+    asked to perform an incremental fetch using any provided ``cursor``.  Any
+    exception raised bubbles up to the worker which will trigger retry/backoff
+    behaviour.
+    """
+    client = payload.get("client")
+    if client is None:
+        raise ValueError("sync_app_events requires a 'client' in payload")
+    provider = payload.get("provider", "google")
+    cursor = payload.get("cursor")
+    client.fetch_since(provider, cursor)


### PR DESCRIPTION
## Summary
- persist etags and sync timestamps for events and staging tables
- resolve sync conflicts by copying local edits and updating with remote changes
- run calendar sync as background worker job with retry/backoff and optional delay
- add regression test for conflict policy and migration for new columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5a8b8550832ead772507c0923b21