### PR TITLE
feat: track learning-loop session metrics

### DIFF
--- a/migrations/versions/0008_metrics_tables.py
+++ b/migrations/versions/0008_metrics_tables.py
@@ -1,0 +1,27 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0008_metrics_tables'
+down_revision = '0007_sync_etags_and_stamps'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'session_log',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('task_id', sa.Integer(), nullable=False),
+        sa.Column('planned_minutes', sa.Integer(), nullable=False),
+        sa.Column('actual_minutes', sa.Integer(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('course_label', sa.String(), nullable=True),
+        sa.Column('logged_at', sa.String(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    op.create_index('session_log_type_course_idx', 'session_log', ['type', 'course_label'])
+
+
+def downgrade():
+    op.drop_index('session_log_type_course_idx', table_name='session_log')
+    op.drop_table('session_log')

--- a/project/metrics.py
+++ b/project/metrics.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import text
+
+from .db import get_engine
+from .settings import load_settings
+
+ALPHA = 0.3
+
+
+def _engine():
+    settings = load_settings()
+    return get_engine(settings.sqlite_path)
+
+
+def record_session(
+    task_id: int,
+    planned_minutes: int,
+    actual_minutes: int,
+    task_type: str,
+    course_label: Optional[str],
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Record a completed study session."""
+    ts = (timestamp or datetime.utcnow()).isoformat()
+    engine = _engine()
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO session_log (task_id, planned_minutes, actual_minutes, type, course_label, logged_at)
+                VALUES (:task_id, :planned, :actual, :type, :course, :ts)
+                """
+            ),
+            {
+                "task_id": task_id,
+                "planned": planned_minutes,
+                "actual": actual_minutes,
+                "type": task_type,
+                "course": course_label,
+                "ts": ts,
+            },
+        )
+
+
+def get_estimate(task_type: Optional[str], course_label: Optional[str], default_minutes: int) -> int:
+    """Return EWMA estimate for session minutes."""
+    engine = _engine()
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT actual_minutes FROM session_log
+                WHERE type = :type
+                  AND ((course_label = :course) OR (course_label IS NULL AND :course IS NULL))
+                ORDER BY logged_at
+                """
+            ),
+            {"type": task_type, "course": course_label},
+        ).fetchall()
+    estimate = float(default_minutes)
+    for r in rows:
+        estimate = ALPHA * float(r.actual_minutes) + (1 - ALPHA) * estimate
+    return int(round(estimate))

--- a/tests/test_learning_loop.py
+++ b/tests/test_learning_loop.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime, time
+
+from sqlalchemy import text
+
+from project.db import get_engine, ensure_db
+from project.prefs import UserPrefs
+from project import metrics
+from agents import planner_engine
+
+
+def _init_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = get_engine(str(db_path))
+    ensure_db(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE session_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id INTEGER NOT NULL,
+                    planned_minutes INTEGER NOT NULL,
+                    actual_minutes INTEGER NOT NULL,
+                    type TEXT NOT NULL,
+                    course_label TEXT,
+                    logged_at TEXT NOT NULL
+                )
+                """
+            )
+        )
+    return engine, db_path
+
+
+def _settings(db_path, flag: bool):
+    class S:
+        sqlite_path = str(db_path)
+        enable_learning_loop = flag
+    return S()
+
+
+def test_record_session_logs(tmp_path, monkeypatch):
+    engine, db_path = _init_db(tmp_path)
+    settings = _settings(db_path, True)
+    monkeypatch.setattr(metrics, "load_settings", lambda: settings)
+    metrics.record_session(1, 50, 40, "study", "math")
+    with engine.begin() as conn:
+        row = conn.execute(text("SELECT task_id, planned_minutes, actual_minutes, type, course_label FROM session_log"))
+        rec = row.fetchone()
+        assert rec.task_id == 1
+        assert rec.planned_minutes == 50
+        assert rec.actual_minutes == 40
+        assert rec.type == "study"
+        assert rec.course_label == "math"
+
+
+def test_planner_uses_adjusted_estimate(tmp_path, monkeypatch):
+    engine, db_path = _init_db(tmp_path)
+    settings = _settings(db_path, True)
+    monkeypatch.setattr(metrics, "load_settings", lambda: settings)
+    monkeypatch.setattr(planner_engine, "load_settings", lambda: settings)
+    metrics.record_session(1, 50, 30, "study", "math")
+    tasks = [{"id": 1, "title": "T", "type": "study", "course_label": "math", "estimated_duration": 60}]
+    prefs = UserPrefs(day_start=time(8, 0), day_end=time(20, 0), default_session_minutes=50, max_sessions_per_day=3)
+    base = datetime(2024, 1, 1, 8, 0)
+    sessions = planner_engine.schedule(tasks, [], [], prefs, start=base)
+    first = sessions[0]
+    minutes = int((first["end_time"] - first["start_time"]).total_seconds() / 60)
+    assert minutes == 44  # 0.3*30 + 0.7*50
+
+
+def test_flag_off_no_change(tmp_path, monkeypatch):
+    engine, db_path = _init_db(tmp_path)
+    settings_on = _settings(db_path, True)
+    monkeypatch.setattr(metrics, "load_settings", lambda: settings_on)
+    metrics.record_session(1, 50, 30, "study", "math")
+    settings_off = _settings(db_path, False)
+    monkeypatch.setattr(planner_engine, "load_settings", lambda: settings_off)
+    monkeypatch.setattr(metrics, "load_settings", lambda: settings_off)
+    tasks = [{"id": 1, "title": "T", "type": "study", "course_label": "math", "estimated_duration": 60}]
+    prefs = UserPrefs(day_start=time(8, 0), day_end=time(20, 0), default_session_minutes=50, max_sessions_per_day=3)
+    base = datetime(2024, 1, 1, 8, 0)
+    sessions = planner_engine.schedule(tasks, [], [], prefs, start=base)
+    minutes = int((sessions[0]["end_time"] - sessions[0]["start_time"]).total_seconds() / 60)
+    assert minutes == 50


### PR DESCRIPTION
## Summary
- log completed study sessions with actual vs planned minutes
- use EWMA-adjusted session duration estimates in planner when learning loop enabled
- add migration and tests for session metrics

## Testing
- `pytest -q`
- `QT_QPA_PLATFORM=offscreen timeout 5 python -m scripts.dev_run` *(fails: type object 'QEvent' has no attribute 'MouseMove')*


------
https://chatgpt.com/codex/tasks/task_e_689a5d3f600c832eb2967052c3d3b5b9