### PR TITLE
Harden migrations and improve type safety

### DIFF
--- a/docs/adr/0005-supabase-first.md
+++ b/docs/adr/0005-supabase-first.md
@@ -1,26 +1,30 @@
 # ADR 0005: Supabase-first Architecture with Local SQLite Cache
 
 ## Status
+
 Accepted
 
 ## Context
+
 The application originally persisted all data in a local SQLite database and
 used ad-hoc sync with Google Calendar. To support multi-device access and
-reliable offline behaviour, a cloud source of truth was required.
+reliable offline behavior, a cloud source of truth was required.
 
 ## Decision
+
 - Supabase (Postgres) is the primary store. Row Level Security enforces
   per-user isolation with `owner_user_id = auth.uid()`.
 - A local SQLite database mirrors remote state and queues mutations while
-offline. Writes go to Supabase when online and are flagged `dirty` when
-queued locally.
+  offline. Writes go to Supabase when online and are flagged `dirty` when
+  queued locally.
 - A background `SyncEngine` drains the `pending_ops` queue and reconciles
-changes using last-writer-wins semantics.
+  changes using last-writer-wins semantics.
 
 ## Consequences
+
 - Users can continue working offline; updates are pushed when connectivity
-returns.
+  returns.
 - Conflict resolution is simplified to last-writer-wins based on server
-`updated_at` timestamps and a `version` UUID.
+  `updated_at` timestamps and a `version` UUID.
 - Additional complexity exists in the repository layer and migrations to
-support mirrored schemas.
+  support mirrored schemas.

--- a/migrations/versions/0007_sync_etags_and_stamps.py
+++ b/migrations/versions/0007_sync_etags_and_stamps.py
@@ -1,26 +1,105 @@
+"""Sync metadata for events and staging events.
+
+This migration is written to be *idempotent* and resilient to partially
+applied previous attempts. SQLite requires batch mode for many schema
+changes which creates temporary tables. Failed runs can leave those
+temporary tables behind; the helper below ensures they are cleaned up
+before proceeding.
+"""
+
+from __future__ import annotations
+
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
-revision = '0007_sync_etags_and_stamps'
-down_revision = '0006_calendar_indexes'
+revision = "0007_sync_etags_and_stamps"
+down_revision = "0006_calendar_indexes"
 branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    with op.batch_alter_table('events') as batch:
-        batch.add_column(sa.Column('etag', sa.String(), nullable=True))
-        batch.add_column(sa.Column('updated_at', sa.String(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')))
-        batch.add_column(sa.Column('last_synced_at', sa.String(), nullable=True))
-    with op.batch_alter_table('staging_events') as batch:
-        batch.add_column(sa.Column('etag', sa.String(), nullable=True))
+def _drop_sqlite_tmp_tables() -> None:
+    """Remove leftover _alembic_tmp_* tables from failed batch migrations."""
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        return
+    for tbl in ("_alembic_tmp_events", "_alembic_tmp_staging_events"):
+        try:
+            bind.execute(sa.text(f"DROP TABLE IF EXISTS {tbl}"))
+        except Exception:  # pragma: no cover - defensive
+            pass
 
-def downgrade():
-    with op.batch_alter_table('staging_events') as batch:
-        batch.drop_column('etag')
-    with op.batch_alter_table('events') as batch:
-        batch.drop_column('last_synced_at')
-        batch.drop_column('updated_at')
-        batch.drop_column('etag')
+
+def upgrade() -> None:
+    _drop_sqlite_tmp_tables()
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    # ------------------------------------------------------------------
+    # Ensure staging_events table exists
+    if not insp.has_table("staging_events"):
+        op.create_table(
+            "staging_events",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("source", sa.String(), nullable=False, server_default=""),
+            sa.Column("source_id", sa.String(), nullable=False, server_default=""),
+            sa.Column("payload", sa.Text(), nullable=False, server_default=""),
+        )
+        insp = sa.inspect(bind)
+
+    st_cols = {c["name"] for c in insp.get_columns("staging_events")}
+    with op.batch_alter_table("staging_events") as batch:
+        if "etag" not in st_cols:
+            batch.add_column(sa.Column("etag", sa.String()))
+        if "sync_timestamp" not in st_cols:
+            batch.add_column(sa.Column("sync_timestamp", sa.String()))
+
+    # ------------------------------------------------------------------
+    # Add sync metadata to events table
+    ev_cols = {c["name"] for c in insp.get_columns("events")}
+    needed = any(
+        name not in ev_cols
+        for name in ("etag", "updated_at", "last_synced_at", "app_owned", "app_tag")
+    )
+    if needed:
+        with op.batch_alter_table("events") as batch:
+            if "etag" not in ev_cols:
+                batch.add_column(sa.Column("etag", sa.String()))
+            if "updated_at" not in ev_cols:
+                batch.add_column(
+                    sa.Column(
+                        "updated_at",
+                        sa.String(),
+                        nullable=False,
+                        server_default=sa.text("CURRENT_TIMESTAMP"),
+                    )
+                )
+            if "last_synced_at" not in ev_cols:
+                batch.add_column(sa.Column("last_synced_at", sa.String()))
+            if "app_owned" not in ev_cols:
+                batch.add_column(
+                    sa.Column("app_owned", sa.Integer(), nullable=False, server_default="0")
+                )
+            if "app_tag" not in ev_cols:
+                batch.add_column(sa.Column("app_tag", sa.String()))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("staging_events"):
+        st_cols = {c["name"] for c in insp.get_columns("staging_events")}
+        with op.batch_alter_table("staging_events") as batch:
+            if "sync_timestamp" in st_cols:
+                batch.drop_column("sync_timestamp")
+            if "etag" in st_cols:
+                batch.drop_column("etag")
+
+    if insp.has_table("events"):
+        ev_cols = {c["name"] for c in insp.get_columns("events")}
+        with op.batch_alter_table("events") as batch:
+            for name in ["app_tag", "app_owned", "last_synced_at", "updated_at", "etag"]:
+                if name in ev_cols:
+                    batch.drop_column(name)

--- a/tests/test_migrations_sqlite.py
+++ b/tests/test_migrations_sqlite.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+
+def run_migration_0007(db_path: Path) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    # pretend previous migrations already ran
+    command.stamp(cfg, "0006_calendar_indexes")
+    command.upgrade(cfg, "head")
+    return cfg
+
+
+def test_sqlite_migrations_handle_partial_state(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    state TEXT,
+                    due_date TEXT
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    owner_user_id TEXT,
+                    source TEXT NOT NULL,
+                    source_id TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    start_time TEXT NOT NULL,
+                    end_time TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT ''
+                )
+                """
+            )
+        )
+        # stray temp table from failed prior run
+        conn.execute(text("CREATE TABLE IF NOT EXISTS _alembic_tmp_events(id INTEGER)"))
+
+    cfg = run_migration_0007(db_path)
+    # running again should be a no-op
+    command.upgrade(cfg, "head")
+
+    insp = inspect(engine)
+    assert "_alembic_tmp_events" not in insp.get_table_names()
+    assert "staging_events" in insp.get_table_names()
+
+    st_cols = {c["name"] for c in insp.get_columns("staging_events")}
+    assert {"etag", "sync_timestamp"}.issubset(st_cols)
+
+    ev_cols = {c["name"] for c in insp.get_columns("events")}
+    for col in ["etag", "updated_at", "last_synced_at", "app_owned", "app_tag"]:
+        assert col in ev_cols

--- a/tests/test_queue_pending.py
+++ b/tests/test_queue_pending.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from project.db import get_engine, ensure_db
+from project.repo.base import Task
+from project.repo.local_sqlite import LocalCacheRepo
+
+
+def test_queue_pending_resolves_id(tmp_path):
+    db = tmp_path / "test.db"
+    engine = get_engine(str(db))
+    ensure_db(engine)
+    repo = LocalCacheRepo(engine)
+
+    task = Task(
+        id=None,
+        owner_user_id=None,
+        source="app",
+        source_id="abc",
+        title="t",
+        type="study",
+        estimated_duration=1,
+    )
+    repo.upsert_task(task, dirty=True)
+    # queue with missing id; should resolve via source/source_id
+    repo.queue_pending("tasks", "upsert", None, task.__dict__)
+
+    with engine.begin() as conn:
+        row = conn.execute(text("SELECT row_local_id FROM pending_ops"))
+        fetched = row.fetchone()
+    assert fetched is not None
+    assert int(fetched[0]) == task.id
+
+
+def test_queue_pending_requires_identifiers(tmp_path):
+    db = tmp_path / "test.db"
+    engine = get_engine(str(db))
+    ensure_db(engine)
+    repo = LocalCacheRepo(engine)
+
+    with pytest.raises(ValueError):
+        repo.queue_pending("tasks", "upsert", None, {"foo": "bar"})

--- a/tests/test_type_coercion.py
+++ b/tests/test_type_coercion.py
@@ -1,0 +1,21 @@
+from ui.pages.tasks import as_int, as_str, as_optional_str
+
+
+def test_as_str():
+    assert as_str("hi") == "hi"
+    assert as_str(123) == "123"
+    assert as_str(None) == ""
+
+
+def test_as_optional_str():
+    assert as_optional_str("hi") == "hi"
+    assert as_optional_str(123) == "123"
+    assert as_optional_str("") is None
+    assert as_optional_str(None) is None
+
+
+def test_as_int():
+    assert as_int(5) == 5
+    assert as_int("7") == 7
+    assert as_int("bad", default=1) == 1
+    assert as_int(None, default=2) == 2

--- a/utils/jobs.py
+++ b/utils/jobs.py
@@ -30,7 +30,7 @@ def sync_app_events(payload: Any) -> None:
     :class:`integrations.google_calendar.GoogleCalendarClient`.  The client is
     asked to perform an incremental fetch using any provided ``cursor``.  Any
     exception raised bubbles up to the worker which will trigger retry/backoff
-    behaviour.
+    behavior.
     """
     client = payload.get("client")
     if client is None:


### PR DESCRIPTION
## Summary
- guard SQLite upserts and pending ops for missing IDs and row lookups
- build SyncingRepo in the main window and add coercion helpers for Task creation
- make 0007 migration idempotent and clean up stray temp tables
- fix Markdown spacing/spelling and add unit/migration tests

## Testing
- `pytest -q`
- `markdownlint docs/adr/0005-supabase-first.md`


------
https://chatgpt.com/codex/tasks/task_e_689d80b6d424832ea5c0fec279a4c1d7